### PR TITLE
Add @moduledoc false to modules that don't need HexDocs documentation (closes #162) and create a basic ExDoc config

### DIFF
--- a/benchmarks/support/fixtures/components/layouts/default_layout.ex
+++ b/benchmarks/support/fixtures/components/layouts/default_layout.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Components.DefaultLayout do
+  @moduledoc false
+
   use Hologram.Component
   alias Hologram.UI.Runtime
 

--- a/benchmarks/support/fixtures/pages/page1.ex
+++ b/benchmarks/support/fixtures/pages/page1.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page1 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page10.ex
+++ b/benchmarks/support/fixtures/pages/page10.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page10 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page100.ex
+++ b/benchmarks/support/fixtures/pages/page100.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page100 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page11.ex
+++ b/benchmarks/support/fixtures/pages/page11.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page11 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page12.ex
+++ b/benchmarks/support/fixtures/pages/page12.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page12 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page13.ex
+++ b/benchmarks/support/fixtures/pages/page13.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page13 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page14.ex
+++ b/benchmarks/support/fixtures/pages/page14.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page14 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page15.ex
+++ b/benchmarks/support/fixtures/pages/page15.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page15 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page16.ex
+++ b/benchmarks/support/fixtures/pages/page16.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page16 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page17.ex
+++ b/benchmarks/support/fixtures/pages/page17.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page17 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page18.ex
+++ b/benchmarks/support/fixtures/pages/page18.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page18 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page19.ex
+++ b/benchmarks/support/fixtures/pages/page19.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page19 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page2.ex
+++ b/benchmarks/support/fixtures/pages/page2.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page2 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page20.ex
+++ b/benchmarks/support/fixtures/pages/page20.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page20 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page21.ex
+++ b/benchmarks/support/fixtures/pages/page21.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page21 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page22.ex
+++ b/benchmarks/support/fixtures/pages/page22.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page22 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page23.ex
+++ b/benchmarks/support/fixtures/pages/page23.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page23 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page24.ex
+++ b/benchmarks/support/fixtures/pages/page24.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page24 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page25.ex
+++ b/benchmarks/support/fixtures/pages/page25.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page25 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page26.ex
+++ b/benchmarks/support/fixtures/pages/page26.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page26 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page27.ex
+++ b/benchmarks/support/fixtures/pages/page27.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page27 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page28.ex
+++ b/benchmarks/support/fixtures/pages/page28.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page28 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page29.ex
+++ b/benchmarks/support/fixtures/pages/page29.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page29 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page3.ex
+++ b/benchmarks/support/fixtures/pages/page3.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page3 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page30.ex
+++ b/benchmarks/support/fixtures/pages/page30.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page30 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page31.ex
+++ b/benchmarks/support/fixtures/pages/page31.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page31 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page32.ex
+++ b/benchmarks/support/fixtures/pages/page32.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page32 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page33.ex
+++ b/benchmarks/support/fixtures/pages/page33.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page33 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page34.ex
+++ b/benchmarks/support/fixtures/pages/page34.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page34 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page35.ex
+++ b/benchmarks/support/fixtures/pages/page35.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page35 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page36.ex
+++ b/benchmarks/support/fixtures/pages/page36.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page36 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page37.ex
+++ b/benchmarks/support/fixtures/pages/page37.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page37 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page38.ex
+++ b/benchmarks/support/fixtures/pages/page38.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page38 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page39.ex
+++ b/benchmarks/support/fixtures/pages/page39.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page39 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page4.ex
+++ b/benchmarks/support/fixtures/pages/page4.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page4 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page40.ex
+++ b/benchmarks/support/fixtures/pages/page40.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page40 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page41.ex
+++ b/benchmarks/support/fixtures/pages/page41.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page41 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page42.ex
+++ b/benchmarks/support/fixtures/pages/page42.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page42 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page43.ex
+++ b/benchmarks/support/fixtures/pages/page43.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page43 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page44.ex
+++ b/benchmarks/support/fixtures/pages/page44.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page44 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page45.ex
+++ b/benchmarks/support/fixtures/pages/page45.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page45 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page46.ex
+++ b/benchmarks/support/fixtures/pages/page46.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page46 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page47.ex
+++ b/benchmarks/support/fixtures/pages/page47.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page47 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page48.ex
+++ b/benchmarks/support/fixtures/pages/page48.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page48 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page49.ex
+++ b/benchmarks/support/fixtures/pages/page49.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page49 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page5.ex
+++ b/benchmarks/support/fixtures/pages/page5.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page5 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page50.ex
+++ b/benchmarks/support/fixtures/pages/page50.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page50 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page51.ex
+++ b/benchmarks/support/fixtures/pages/page51.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page51 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page52.ex
+++ b/benchmarks/support/fixtures/pages/page52.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page52 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page53.ex
+++ b/benchmarks/support/fixtures/pages/page53.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page53 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page54.ex
+++ b/benchmarks/support/fixtures/pages/page54.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page54 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page55.ex
+++ b/benchmarks/support/fixtures/pages/page55.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page55 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page56.ex
+++ b/benchmarks/support/fixtures/pages/page56.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page56 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page57.ex
+++ b/benchmarks/support/fixtures/pages/page57.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page57 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page58.ex
+++ b/benchmarks/support/fixtures/pages/page58.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page58 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page59.ex
+++ b/benchmarks/support/fixtures/pages/page59.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page59 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page6.ex
+++ b/benchmarks/support/fixtures/pages/page6.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page6 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page60.ex
+++ b/benchmarks/support/fixtures/pages/page60.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page60 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page61.ex
+++ b/benchmarks/support/fixtures/pages/page61.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page61 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page62.ex
+++ b/benchmarks/support/fixtures/pages/page62.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page62 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page63.ex
+++ b/benchmarks/support/fixtures/pages/page63.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page63 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page64.ex
+++ b/benchmarks/support/fixtures/pages/page64.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page64 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page65.ex
+++ b/benchmarks/support/fixtures/pages/page65.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page65 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page66.ex
+++ b/benchmarks/support/fixtures/pages/page66.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page66 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page67.ex
+++ b/benchmarks/support/fixtures/pages/page67.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page67 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page68.ex
+++ b/benchmarks/support/fixtures/pages/page68.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page68 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page69.ex
+++ b/benchmarks/support/fixtures/pages/page69.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page69 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page7.ex
+++ b/benchmarks/support/fixtures/pages/page7.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page7 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page70.ex
+++ b/benchmarks/support/fixtures/pages/page70.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page70 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page71.ex
+++ b/benchmarks/support/fixtures/pages/page71.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page71 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page72.ex
+++ b/benchmarks/support/fixtures/pages/page72.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page72 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page73.ex
+++ b/benchmarks/support/fixtures/pages/page73.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page73 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page74.ex
+++ b/benchmarks/support/fixtures/pages/page74.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page74 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page75.ex
+++ b/benchmarks/support/fixtures/pages/page75.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page75 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page76.ex
+++ b/benchmarks/support/fixtures/pages/page76.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page76 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page77.ex
+++ b/benchmarks/support/fixtures/pages/page77.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page77 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page78.ex
+++ b/benchmarks/support/fixtures/pages/page78.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page78 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page79.ex
+++ b/benchmarks/support/fixtures/pages/page79.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page79 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page8.ex
+++ b/benchmarks/support/fixtures/pages/page8.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page8 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page80.ex
+++ b/benchmarks/support/fixtures/pages/page80.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page80 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page81.ex
+++ b/benchmarks/support/fixtures/pages/page81.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page81 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page82.ex
+++ b/benchmarks/support/fixtures/pages/page82.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page82 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page83.ex
+++ b/benchmarks/support/fixtures/pages/page83.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page83 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page84.ex
+++ b/benchmarks/support/fixtures/pages/page84.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page84 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page85.ex
+++ b/benchmarks/support/fixtures/pages/page85.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page85 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page86.ex
+++ b/benchmarks/support/fixtures/pages/page86.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page86 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page87.ex
+++ b/benchmarks/support/fixtures/pages/page87.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page87 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page88.ex
+++ b/benchmarks/support/fixtures/pages/page88.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page88 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page89.ex
+++ b/benchmarks/support/fixtures/pages/page89.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page89 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page9.ex
+++ b/benchmarks/support/fixtures/pages/page9.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page9 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page90.ex
+++ b/benchmarks/support/fixtures/pages/page90.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page90 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page91.ex
+++ b/benchmarks/support/fixtures/pages/page91.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page91 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page92.ex
+++ b/benchmarks/support/fixtures/pages/page92.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page92 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page93.ex
+++ b/benchmarks/support/fixtures/pages/page93.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page93 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page94.ex
+++ b/benchmarks/support/fixtures/pages/page94.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page94 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page95.ex
+++ b/benchmarks/support/fixtures/pages/page95.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page95 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page96.ex
+++ b/benchmarks/support/fixtures/pages/page96.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page96 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page97.ex
+++ b/benchmarks/support/fixtures/pages/page97.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page97 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page98.ex
+++ b/benchmarks/support/fixtures/pages/page98.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page98 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/benchmarks/support/fixtures/pages/page99.ex
+++ b/benchmarks/support/fixtures/pages/page99.ex
@@ -1,5 +1,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.Specs
 defmodule Hologram.Benchmarks.Fixtures.Page99 do
+  @moduledoc false
+
   use Hologram.Page
 
   import Hologram.Commons.KernelUtils, only: [inspect: 1]

--- a/lib/hologram/application.ex
+++ b/lib/hologram/application.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Application do
+  @moduledoc false
+
   use Application
 
   @impl Application

--- a/lib/hologram/assets/manifest_cache.ex
+++ b/lib/hologram/assets/manifest_cache.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Assets.ManifestCache do
+  @moduledoc false
+
   use GenServer
   alias Hologram.Assets.PathRegistry, as: AssetPathRegistry
 

--- a/lib/hologram/assets/page_digest_registry.ex
+++ b/lib/hologram/assets/page_digest_registry.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Assets.PageDigestRegistry do
+  @moduledoc false
+
   use GenServer
 
   alias Hologram.Commons.PLT

--- a/lib/hologram/assets/path_registry.ex
+++ b/lib/hologram/assets/path_registry.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Assets.PathRegistry do
+  @moduledoc false
+
   use GenServer
 
   alias Hologram.Commons.ETS

--- a/lib/hologram/benchmarks.ex
+++ b/lib/hologram/benchmarks.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Benchmarks do
+  @moduledoc false
+
   alias Hologram.Commons.CryptographicUtils
   alias Hologram.Commons.PLT
   alias Hologram.Compiler

--- a/lib/hologram/commons/atom_utils.ex
+++ b/lib/hologram/commons/atom_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.AtomUtils do
+  @moduledoc false
+
   @doc """
   Returns `true` if `atom` starts with the given prefix.
   """

--- a/lib/hologram/commons/bitstring_utils.ex
+++ b/lib/hologram/commons/bitstring_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.BitstringUtils do
+  @moduledoc false
+
   @doc """
   Converts a list of bits into a corresponding bitstring.
   """

--- a/lib/hologram/commons/cryptographic_utils.ex
+++ b/lib/hologram/commons/cryptographic_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.CryptographicUtils do
+  @moduledoc false
+
   @doc """
   Calculates the cryptographic digest of the input data using the given algorithm (such as :md5, :sha256, etc.).
   Output format can be either `:hex` (hexadecimal string) or `:binary` (binary data).

--- a/lib/hologram/commons/ets.ex
+++ b/lib/hologram/commons/ets.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.ETS do
+  @moduledoc false
+
   # This helps to avoid Dialyzer warnings related to :ets.tid() type opaqueness.
   @type tid :: :ets.tid() | atom
 

--- a/lib/hologram/commons/file_utils.ex
+++ b/lib/hologram/commons/file_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.FileUtils do
+  @moduledoc false
+
   alias Hologram.Commons.Types, as: T
 
   @doc """

--- a/lib/hologram/commons/guards.ex
+++ b/lib/hologram/commons/guards.ex
@@ -1,3 +1,5 @@
 defmodule Hologram.Commons.Guards do
+  @moduledoc false
+
   defguard is_regex(term) when is_map(term) and term.__struct__ == Regex
 end

--- a/lib/hologram/commons/integer_utils.ex
+++ b/lib/hologram/commons/integer_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.IntegerUtils do
+  @moduledoc false
+
   @doc """
   Counts the number of digits in the given integer.
 

--- a/lib/hologram/commons/kernel_utils.ex
+++ b/lib/hologram/commons/kernel_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.KernelUtils do
+  @moduledoc false
+
   @doc """
   Inspects the given argument according to the Inspect protocol.
   Maps inspection is deterministic by sorting their key-value pairs.

--- a/lib/hologram/commons/plt.ex
+++ b/lib/hologram/commons/plt.ex
@@ -1,9 +1,9 @@
 defmodule Hologram.Commons.PLT do
-  @moduledoc """
-  Provides a persistent lookup table (PLT) implemented using ETS (Erlang Term Storage) and GenServer.
-  It allows to store key-value pairs in memory and perform various operations on the data.
-  The data in memory can be dumped to a file and loaded from a file.
-  """
+  @moduledoc false
+
+  # Provides a persistent lookup table (PLT) implemented using ETS (Erlang Term Storage) and GenServer.
+  # It allows to store key-value pairs in memory and perform various operations on the data.
+  # The data in memory can be dumped to a file and loaded from a file.
 
   use GenServer
 

--- a/lib/hologram/commons/process_utils.ex
+++ b/lib/hologram/commons/process_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.ProcessUtils do
+  @moduledoc false
+
   @doc """
   Tells whether the process with the given name is running.
   """

--- a/lib/hologram/commons/serialization_utils.ex
+++ b/lib/hologram/commons/serialization_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.SerializationUtils do
+  @moduledoc false
+
   @doc """
   Deserializes binary data to Elixir term.
 

--- a/lib/hologram/commons/string_utils.ex
+++ b/lib/hologram/commons/string_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.StringUtils do
+  @moduledoc false
+
   @doc """
   Prepends the prefix to the given string.
 

--- a/lib/hologram/commons/system_utils.ex
+++ b/lib/hologram/commons/system_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.SystemUtils do
+  @moduledoc false
+
   alias Hologram.Commons.IntegerUtils
 
   @doc """

--- a/lib/hologram/commons/task_utils.ex
+++ b/lib/hologram/commons/task_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.TaskUtils do
+  @moduledoc false
+
   @doc """
   Starts multiple tasks.
   """

--- a/lib/hologram/commons/test_utils.ex
+++ b/lib/hologram/commons/test_utils.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.TestUtils do
+  @moduledoc false
+
   alias Hologram.Commons.IntegerUtils
   alias Hologram.Commons.KernelUtils
   alias Hologram.Reflection

--- a/lib/hologram/commons/types.ex
+++ b/lib/hologram/commons/types.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Commons.Types do
+  @moduledoc false
+
   @type alias_segments :: list(atom)
 
   @type file_path :: String.t()

--- a/lib/hologram/compiler.ex
+++ b/lib/hologram/compiler.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler do
+  @moduledoc false
+
   alias Hologram.Commons.CryptographicUtils
   alias Hologram.Commons.PLT
   alias Hologram.Commons.TaskUtils

--- a/lib/hologram/compiler/ast.ex
+++ b/lib/hologram/compiler/ast.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.AST do
+  @moduledoc false
+
   alias Hologram.Compiler.AST
   alias Hologram.Compiler.Normalizer
 

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.CallGraph do
+  @moduledoc false
+
   alias Hologram.Commons.PLT
   alias Hologram.Commons.SerializationUtils
   alias Hologram.Commons.TaskUtils

--- a/lib/hologram/compiler/context.ex
+++ b/lib/hologram/compiler/context.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.Context do
+  @moduledoc false
+
   @type t :: %__MODULE__{
           match_operator?: bool,
           module: module,

--- a/lib/hologram/compiler/encoder.ex
+++ b/lib/hologram/compiler/encoder.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.Encoder do
+  @moduledoc false
+
   if Application.compile_env(:hologram, :debug_encoder) do
     use Interceptor.Annotated,
       config: %{

--- a/lib/hologram/compiler/helpers.ex
+++ b/lib/hologram/compiler/helpers.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.Helpers do
+  @moduledoc false
+
   alias Hologram.Commons.Types, as: T
 
   @doc """

--- a/lib/hologram/compiler/ir.ex
+++ b/lib/hologram/compiler/ir.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.IR do
+  @moduledoc false
+
   alias Hologram.Commons.AtomUtils
   alias Hologram.Commons.SystemUtils
   alias Hologram.Compiler.AST
@@ -47,12 +49,16 @@ defmodule Hologram.Compiler.IR do
           | IR.With.t()
 
   defmodule AnonymousFunctionCall do
+    @moduledoc false
+
     defstruct [:function, :args]
 
     @type t :: %__MODULE__{function: IR.t(), args: list(IR.t())}
   end
 
   defmodule AnonymousFunctionType do
+    @moduledoc false
+
     defstruct [:arity, :captured_function, :captured_module, :clauses]
 
     @type t :: %__MODULE__{
@@ -64,12 +70,16 @@ defmodule Hologram.Compiler.IR do
   end
 
   defmodule AtomType do
+    @moduledoc false
+
     defstruct [:value]
 
     @type t :: %__MODULE__{value: atom}
   end
 
   defmodule BitstringSegment do
+    @moduledoc false
+
     defstruct [:value, :modifiers]
 
     @type(
@@ -83,30 +93,40 @@ defmodule Hologram.Compiler.IR do
   end
 
   defmodule BitstringType do
+    @moduledoc false
+
     defstruct [:segments]
 
     @type t :: %__MODULE__{segments: list(IR.BitstringSegment.t())}
   end
 
   defmodule Block do
+    @moduledoc false
+
     defstruct [:expressions]
 
     @type t :: %__MODULE__{expressions: list(IR.t())}
   end
 
   defmodule Case do
+    @moduledoc false
+
     defstruct [:condition, :clauses]
 
     @type t :: %__MODULE__{condition: IR.t(), clauses: list(IR.Clause.t())}
   end
 
   defmodule Clause do
+    @moduledoc false
+
     defstruct [:match, :guards, :body]
 
     @type t :: %__MODULE__{match: IR.t(), guards: list(IR.t()), body: IR.Block.t()}
   end
 
   defmodule Comprehension do
+    @moduledoc false
+
     defstruct [:generators, :filters, :collectable, :unique, :mapper, :reducer]
 
     @type t :: %__MODULE__{
@@ -125,48 +145,64 @@ defmodule Hologram.Compiler.IR do
   end
 
   defmodule ComprehensionFilter do
+    @moduledoc false
+
     defstruct [:expression]
 
     @type t :: %__MODULE__{expression: IR.t()}
   end
 
   defmodule Cond do
+    @moduledoc false
+
     defstruct [:clauses]
 
     @type t :: %__MODULE__{clauses: list(IR.CondClause.t())}
   end
 
   defmodule CondClause do
+    @moduledoc false
+
     defstruct [:condition, :body]
 
     @type t :: %__MODULE__{condition: IR.t(), body: IR.Block.t()}
   end
 
   defmodule ConsOperator do
+    @moduledoc false
+
     defstruct [:head, :tail]
 
     @type t :: %__MODULE__{head: IR.t(), tail: IR.t()}
   end
 
   defmodule DotOperator do
+    @moduledoc false
+
     defstruct [:left, :right]
 
     @type t :: %__MODULE__{left: IR.t(), right: IR.t()}
   end
 
   defmodule FloatType do
+    @moduledoc false
+
     defstruct [:value]
 
     @type t :: %__MODULE__{value: float}
   end
 
   defmodule FunctionClause do
+    @moduledoc false
+
     defstruct [:params, :guards, :body]
 
     @type t :: %__MODULE__{params: list(IR.t()), guards: list(IR.t()), body: IR.Block.t()}
   end
 
   defmodule FunctionDefinition do
+    @moduledoc false
+
     defstruct [:name, :arity, :visibility, :clause]
 
     @type t :: %__MODULE__{
@@ -178,96 +214,128 @@ defmodule Hologram.Compiler.IR do
   end
 
   defmodule IgnoredExpression do
+    @moduledoc false
+
     defstruct [:type]
 
     @type t :: %__MODULE__{type: :public_macro_definition | :private_macro_definition}
   end
 
   defmodule IntegerType do
+    @moduledoc false
+
     defstruct [:value]
 
     @type t :: %__MODULE__{value: integer}
   end
 
   defmodule ListType do
+    @moduledoc false
+
     defstruct [:data]
 
     @type t :: %__MODULE__{data: list(IR.t())}
   end
 
   defmodule LocalFunctionCall do
+    @moduledoc false
+
     defstruct [:function, :args]
 
     @type t :: %__MODULE__{function: atom, args: list(IR.t())}
   end
 
   defmodule MapType do
+    @moduledoc false
+
     defstruct [:data]
 
     @type t :: %__MODULE__{data: list({IR.t(), IR.t()})}
   end
 
   defmodule MatchOperator do
+    @moduledoc false
+
     defstruct [:left, :right]
 
     @type t :: %__MODULE__{left: IR.t(), right: IR.t()}
   end
 
   defmodule MatchPlaceholder do
+    @moduledoc false
+
     defstruct []
 
     @type t :: %__MODULE__{}
   end
 
   defmodule ModuleAttributeOperator do
+    @moduledoc false
+
     defstruct [:name]
 
     @type t :: %__MODULE__{name: atom}
   end
 
   defmodule ModuleDefinition do
+    @moduledoc false
+
     defstruct [:module, :body]
 
     @type t :: %__MODULE__{module: IR.AtomType.t(), body: IR.Block.t()}
   end
 
   defmodule PIDType do
+    @moduledoc false
+
     defstruct [:value]
 
     @type t :: %__MODULE__{value: pid}
   end
 
   defmodule PinOperator do
+    @moduledoc false
+
     defstruct [:name]
 
     @type t :: %__MODULE__{name: atom}
   end
 
   defmodule PortType do
+    @moduledoc false
+
     defstruct [:value]
 
     @type t :: %__MODULE__{value: port}
   end
 
   defmodule ReferenceType do
+    @moduledoc false
+
     defstruct [:value]
 
     @type t :: %__MODULE__{value: reference}
   end
 
   defmodule RemoteFunctionCall do
+    @moduledoc false
+
     defstruct [:module, :function, :args]
 
     @type t :: %__MODULE__{module: IR.t(), function: IR.t(), args: list(IR.t())}
   end
 
   defmodule StringType do
+    @moduledoc false
+
     defstruct [:value]
 
     @type t :: %__MODULE__{value: String.t()}
   end
 
   defmodule Try do
+    @moduledoc false
+
     defstruct [:body, :rescue_clauses, :catch_clauses, :else_clauses, :after_block]
 
     @type t :: %__MODULE__{
@@ -280,6 +348,8 @@ defmodule Hologram.Compiler.IR do
   end
 
   defmodule TryCatchClause do
+    @moduledoc false
+
     defstruct [:kind, :value, :guards, :body]
 
     @type t :: %__MODULE__{
@@ -291,18 +361,24 @@ defmodule Hologram.Compiler.IR do
   end
 
   defmodule TryRescueClause do
+    @moduledoc false
+
     defstruct [:variable, :modules, :body]
 
     @type t :: %__MODULE__{variable: atom, modules: list(module), body: IR.Block.t()}
   end
 
   defmodule TupleType do
+    @moduledoc false
+
     defstruct [:data]
 
     @type t :: %__MODULE__{data: list(IR.t())}
   end
 
   defmodule Variable do
+    @moduledoc false
+
     defstruct [:name]
 
     @type t :: %__MODULE__{name: atom}
@@ -310,6 +386,8 @@ defmodule Hologram.Compiler.IR do
 
   # TODO: finish implementing
   defmodule With do
+    @moduledoc false
+
     defstruct []
 
     @type t :: %__MODULE__{}

--- a/lib/hologram/compiler/normalizer.ex
+++ b/lib/hologram/compiler/normalizer.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.Normalizer do
+  @moduledoc false
+
   alias Hologram.Compiler.AST
   alias Hologram.Compiler.Helpers
   alias Hologram.Reflection

--- a/lib/hologram/compiler/transformer.ex
+++ b/lib/hologram/compiler/transformer.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Compiler.Transformer do
+  @moduledoc false
+
   if Application.compile_env(:hologram, :debug_transformer) do
     use Interceptor.Annotated,
       config: %{

--- a/lib/hologram/controller.ex
+++ b/lib/hologram/controller.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Controller do
+  @moduledoc false
+
   alias Hologram.Template.Renderer
   alias Phoenix.Controller
 

--- a/lib/hologram/endpoint.ex
+++ b/lib/hologram/endpoint.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Endpoint do
+  @moduledoc false
+
   defmacro __using__(_opts) do
     quote do
       import Hologram.Endpoint, only: [hologram_socket: 0]

--- a/lib/hologram/live_reload.ex
+++ b/lib/hologram/live_reload.ex
@@ -1,5 +1,7 @@
 # TODO: test
 defmodule Hologram.LiveReload do
+  @moduledoc false
+
   use GenServer
 
   alias Hologram.Assets.ManifestCache

--- a/lib/hologram/reflection.ex
+++ b/lib/hologram/reflection.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Reflection do
+  @moduledoc false
+
   alias Hologram.Commons.StringUtils
 
   @call_graph_dump_file_name "call_graph.bin"

--- a/lib/hologram/router/page_module_resolver.ex
+++ b/lib/hologram/router/page_module_resolver.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Router.PageModuleResolver do
+  @moduledoc false
+
   use GenServer
 
   alias Hologram.Reflection

--- a/lib/hologram/router/search_tree.ex
+++ b/lib/hologram/router/search_tree.ex
@@ -1,7 +1,11 @@
 defmodule Hologram.Router.SearchTree do
+  @moduledoc false
+
   alias Hologram.Router.SearchTree
 
   defmodule Node do
+    @moduledoc false
+
     defstruct value: nil, children: %{}
 
     @type t :: %__MODULE__{value: module | nil, children: %{String.t() => __MODULE__.t()}}

--- a/lib/hologram/socket/channel.ex
+++ b/lib/hologram/socket/channel.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Socket.Channel do
+  @moduledoc false
+
   use Phoenix.Channel
 
   alias Hologram.Assets.PageDigestRegistry

--- a/lib/hologram/socket/decoder.ex
+++ b/lib/hologram/socket/decoder.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Socket.Decoder do
+  @moduledoc false
+
   alias Hologram.Commons.BitstringUtils
   alias Hologram.Commons.IntegerUtils
 

--- a/lib/hologram/template.ex
+++ b/lib/hologram/template.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Template do
+  @moduledoc false
+
   alias Hologram.Compiler.AST
   alias Hologram.Template.DOM
   alias Hologram.Template.Parser

--- a/lib/hologram/template/dom.ex
+++ b/lib/hologram/template/dom.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Template.DOM do
+  @moduledoc false
+
   alias Hologram.Compiler.AST
   alias Hologram.Template.Helpers
   alias Hologram.Template.Parser

--- a/lib/hologram/template/helpers.ex
+++ b/lib/hologram/template/helpers.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Template.Helpers do
+  @moduledoc false
+
   # See: https://html.spec.whatwg.org/multipage/syntax.html#void-elements
   @void_html_elements [
     "area",

--- a/lib/hologram/template/parser.ex
+++ b/lib/hologram/template/parser.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Template.Parser do
+  @moduledoc false
+
   if Application.compile_env(:hologram, :debug_parser) do
     use Interceptor.Annotated,
       config: %{
@@ -57,6 +59,8 @@ defmodule Hologram.Template.Parser do
           | :start_tag_name
 
   defmodule Context do
+    @moduledoc false
+
     defstruct attribute_name: nil,
               attribute_value: [],
               attributes: [],

--- a/lib/hologram/template/renderer.ex
+++ b/lib/hologram/template/renderer.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Template.Renderer do
+  @moduledoc false
+
   alias Hologram.Assets.PageDigestRegistry
   alias Hologram.Commons.StringUtils
   alias Hologram.Commons.Types, as: T
@@ -13,6 +15,8 @@ defmodule Hologram.Template.Renderer do
   @void_elems ~w(area base br col embed hr img input link meta param source track wbr)
 
   defmodule Env do
+    @moduledoc false
+
     defstruct context: %{}, node_type: nil, slots: [], tag_name: nil
 
     @type t :: %__MODULE__{

--- a/lib/hologram/template/tokenizer.ex
+++ b/lib/hologram/template/tokenizer.ex
@@ -1,4 +1,6 @@
 defmodule Hologram.Template.Tokenizer do
+  @moduledoc false
+
   @type token :: {:string | :symbol | :whitespace, String.t()}
 
   @doc """

--- a/lib/libgraph/edge.ex
+++ b/lib/libgraph/edge.ex
@@ -1,10 +1,11 @@
 defmodule Graph.Edge do
-  @moduledoc """
-  This module defines the struct used to represent edges and associated metadata about them.
+  @moduledoc false
 
-  Used internally, `v1` and `v2` typically hold vertex ids, not the vertex itself, but all
-  public APIs which return `Graph.Edge` structs, return them with the actual vertices.
-  """
+  # This module defines the struct used to represent edges and associated metadata about them.
+
+  # Used internally, `v1` and `v2` typically hold vertex ids, not the vertex itself, but all
+  # public APIs which return `Graph.Edge` structs, return them with the actual vertices.
+
   defstruct v1: nil,
             v2: nil,
             weight: 1,

--- a/lib/libgraph/graph.ex
+++ b/lib/libgraph/graph.ex
@@ -1,30 +1,31 @@
 defmodule Graph do
-  @moduledoc """
-  This module defines a graph data structure, which supports directed and undirected graphs, in both acyclic and cyclic forms.
-  It also defines the API for creating, manipulating, and querying that structure.
+  @moduledoc false
 
-  As far as memory usage is concerned, `Graph` should be fairly compact in memory, but if you want to do a rough
-  comparison between the memory usage for a graph between `libgraph` and `digraph`, use `:digraph.info/1` and
-  `Graph.info/1` on the two graphs, and both results will contain memory usage information. Keep in mind we don't have a precise
-  way to measure the memory usage of a term in memory, whereas ETS is able to give a more precise answer, but we do have
-  a fairly good way to estimate the usage of a term, and we use that method within `libgraph`.
+  # This module defines a graph data structure, which supports directed and undirected graphs, in both acyclic and cyclic forms.
+  # It also defines the API for creating, manipulating, and querying that structure.
 
-  The Graph struct is structured like so:
+  # As far as memory usage is concerned, `Graph` should be fairly compact in memory, but if you want to do a rough
+  # comparison between the memory usage for a graph between `libgraph` and `digraph`, use `:digraph.info/1` and
+  # `Graph.info/1` on the two graphs, and both results will contain memory usage information. Keep in mind we don't have a precise
+  # way to measure the memory usage of a term in memory, whereas ETS is able to give a more precise answer, but we do have
+  # a fairly good way to estimate the usage of a term, and we use that method within `libgraph`.
 
-  - A map of vertex ids to vertices (`vertices`)
-  - A map of vertex ids to their out neighbors (`out_edges`),
-  - A map of vertex ids to their in neighbors (`in_edges`), effectively the transposition of `out_edges`
-  - A map of vertex ids to vertex labels (`vertex_labels`), (labels are only stored if a non-nil label was provided)
-  - A map of edge ids (where an edge id is simply a tuple of `{vertex_id, vertex_id}`) to a map of edge metadata (`edges`)
-  - Edge metadata is a map of `label => weight`, and each entry in that map represents a distinct edge. This allows
-    us to support multiple edges in the same direction between the same pair of vertices, but for many purposes simply
-    treat them as a single logical edge.
+  # The Graph struct is structured like so:
 
-  This structure is designed to be as efficient as possible once a graph is built, but it turned out that it is also
-  quite efficient for manipulating the graph as well. For example, splitting an edge and introducing a new vertex on that
-  edge can be done with very little effort. We use vertex ids everywhere because we can generate them without any lookups,
-  we don't incur any copies of the vertex structure, and they are very efficient as keys in a map.
-  """
+  # - A map of vertex ids to vertices (`vertices`)
+  # - A map of vertex ids to their out neighbors (`out_edges`),
+  # - A map of vertex ids to their in neighbors (`in_edges`), effectively the transposition of `out_edges`
+  # - A map of vertex ids to vertex labels (`vertex_labels`), (labels are only stored if a non-nil label was provided)
+  # - A map of edge ids (where an edge id is simply a tuple of `{vertex_id, vertex_id}`) to a map of edge metadata (`edges`)
+  # - Edge metadata is a map of `label => weight`, and each entry in that map represents a distinct edge. This allows
+  #   us to support multiple edges in the same direction between the same pair of vertices, but for many purposes simply
+  #   treat them as a single logical edge.
+
+  # This structure is designed to be as efficient as possible once a graph is built, but it turned out that it is also
+  # quite efficient for manipulating the graph as well. For example, splitting an edge and introducing a new vertex on that
+  # edge can be done with very little effort. We use vertex ids everywhere because we can generate them without any lookups,
+  # we don't incur any copies of the vertex structure, and they are very efficient as keys in a map.
+
   defstruct in_edges: %{},
             out_edges: %{},
             edges: %{},

--- a/lib/libgraph/graph/directed.ex
+++ b/lib/libgraph/graph/directed.ex
@@ -1,5 +1,6 @@
 defmodule Graph.Directed do
   @moduledoc false
+
   @compile {:inline, [in_neighbors: 2, in_neighbors: 3, out_neighbors: 2, out_neighbors: 3]}
 
   def batch_topsort(%Graph{} = g) do

--- a/lib/libgraph/graph/edge_specification_error.ex
+++ b/lib/libgraph/graph/edge_specification_error.ex
@@ -1,8 +1,9 @@
 defmodule Graph.EdgeSpecificationError do
-  @moduledoc """
-  This exception is raised when a Graph function expects one or more valid edge specifications,
-  but receives a term which does not match one of the allowed specification patterns.
-  """
+  @moduledoc false
+
+  # This exception is raised when a Graph function expects one or more valid edge specifications,
+  # but receives a term which does not match one of the allowed specification patterns.
+
   defexception [:message]
 
   def exception(value) do

--- a/lib/libgraph/graph/inspect.ex
+++ b/lib/libgraph/graph/inspect.ex
@@ -1,4 +1,6 @@
 defimpl Inspect, for: Graph do
+  @moduledoc false
+
   # For graphs with less than 100 vertices, we'll try to pretty print it,
   # however we should avoid doing so with larger graphs, as it will likely cause outrageous
   # memory consumption, not to mention be expensive to calculate, and the pretty form is not

--- a/lib/libgraph/graph/pathfinding.ex
+++ b/lib/libgraph/graph/pathfinding.ex
@@ -1,7 +1,8 @@
 defmodule Graph.Pathfinding do
-  @moduledoc """
-  This module contains implementation code for path finding algorithms used by `libgraph`.
-  """
+  @moduledoc false
+
+  # This module contains implementation code for path finding algorithms used by `libgraph`.
+
   import Graph.Utils, only: [edge_weight: 3]
 
   @type heuristic_fun :: (Graph.vertex() -> integer)

--- a/lib/libgraph/graph/pathfindings/bellman_ford.ex
+++ b/lib/libgraph/graph/pathfindings/bellman_ford.ex
@@ -1,10 +1,10 @@
 defmodule Graph.Pathfindings.BellmanFord do
-  @moduledoc """
-  The Bellman–Ford algorithm is an algorithm that computes shortest paths from a single
-  source vertex to all of the other vertices in a weighted digraph.
-  It is capable of handling graphs in which some of the edge weights are negative numbers
-  Time complexity: O(VLogV)
-  """
+  @moduledoc false
+
+  # The Bellman–Ford algorithm is an algorithm that computes shortest paths from a single
+  # source vertex to all of the other vertices in a weighted digraph.
+  # It is capable of handling graphs in which some of the edge weights are negative numbers
+  # Time complexity: O(VLogV)
 
   @typep distance() :: %{Graph.vertex_id() => integer()}
 

--- a/lib/libgraph/graph/reducer.ex
+++ b/lib/libgraph/graph/reducer.ex
@@ -1,19 +1,19 @@
 defmodule Graph.Reducer do
-  @moduledoc """
-  Reducers provide a way to traverse a graph while applying a function at each vertex. This
-  can be used for a variety of things, most notably though is pre-processing a graph, for example
-  one might decorate vertices with their distance from some known landmarks for later use in
-  a cost function for A*.
+  @moduledoc false
 
-  The `reduce` function takes a callback which has some control over when to terminate the traversal,
-  to move to the next vertex, return `{:next, acc}`, but to stop traversal and return the accumulator,
-  return `{:halt, acc}`. The `map` function is built on top of `reduce` but does not expose this control,
-  so if you need to map over the graph but stop early, you'll want to build your own `map` implementation
-  on top of `reduce`.
+  # Reducers provide a way to traverse a graph while applying a function at each vertex. This
+  # can be used for a variety of things, most notably though is pre-processing a graph, for example
+  # one might decorate vertices with their distance from some known landmarks for later use in
+  # a cost function for A*.
 
-  Provided out of the box are two reducers, `Graph.Reducers.Bfs` (for breadth-first traversals), and
-  `Graph.Reducers.Dfs` (for depth-first traversals). Simply choose the best one for your use case.
-  """
+  # The `reduce` function takes a callback which has some control over when to terminate the traversal,
+  # to move to the next vertex, return `{:next, acc}`, but to stop traversal and return the accumulator,
+  # return `{:halt, acc}`. The `map` function is built on top of `reduce` but does not expose this control,
+  # so if you need to map over the graph but stop early, you'll want to build your own `map` implementation
+  # on top of `reduce`.
+
+  # Provided out of the box are two reducers, `Graph.Reducers.Bfs` (for breadth-first traversals), and
+  # `Graph.Reducers.Dfs` (for depth-first traversals). Simply choose the best one for your use case.
 
   @callback map(g :: Graph.t(), mapper :: (Graph.vertex() -> term)) :: term
   @callback reduce(g :: Graph.t(), acc :: term, reducer :: (Graph.vertex(), term -> term)) ::

--- a/lib/libgraph/graph/reducers/bfs.ex
+++ b/lib/libgraph/graph/reducers/bfs.ex
@@ -1,7 +1,8 @@
 defmodule Graph.Reducers.Bfs do
-  @moduledoc """
-  This reducer traverses the graph using Breadth-First Search.
-  """
+  @moduledoc false
+
+  # This reducer traverses the graph using Breadth-First Search.
+
   use Graph.Reducer
 
   @doc """

--- a/lib/libgraph/graph/reducers/dfs.ex
+++ b/lib/libgraph/graph/reducers/dfs.ex
@@ -1,7 +1,8 @@
 defmodule Graph.Reducers.Dfs do
-  @moduledoc """
-  This reducer traverses the graph using Depth-First Search.
-  """
+  @moduledoc false
+
+  # This reducer traverses the graph using Depth-First Search.
+
   use Graph.Reducer
 
   @doc """

--- a/lib/libgraph/graph/serializer.ex
+++ b/lib/libgraph/graph/serializer.ex
@@ -1,7 +1,8 @@
 defmodule Graph.Serializer do
-  @moduledoc """
-  This module defines the Serializer behavior for graphs.
-  """
+  @moduledoc false
+
+  # This module defines the Serializer behavior for graphs.
+
   @callback serialize(Graph.t()) :: {:ok, binary} | {:error, term}
 
   defmacro __using__(_) do

--- a/lib/libgraph/graph/serializers/dot.ex
+++ b/lib/libgraph/graph/serializers/dot.ex
@@ -1,8 +1,9 @@
 defmodule Graph.Serializers.DOT do
-  @moduledoc """
-  This serializer converts a Graph to a DOT file, which can then be converted
-  to a great many other formats using Graphviz, e.g. `dot -Tpng out.dot > out.png`.
-  """
+  @moduledoc false
+
+  # This serializer converts a Graph to a DOT file, which can then be converted
+  # to a great many other formats using Graphviz, e.g. `dot -Tpng out.dot > out.png`.
+
   use Graph.Serializer
   alias Graph.Serializer
 

--- a/lib/libgraph/graph/serializers/edgelist.ex
+++ b/lib/libgraph/graph/serializers/edgelist.ex
@@ -1,8 +1,8 @@
 defmodule Graph.Serializers.Edgelist do
-  @moduledoc """
-  This serializer converts a `Graph` to an edgelist suitable for using with
-  graph libraries such as the polyglot igraph library.
-  """
+  @moduledoc false
+
+  # This serializer converts a `Graph` to an edgelist suitable for using with
+  # graph libraries such as the polyglot igraph library.
 
   use Graph.Serializer
   alias Graph.Serializer

--- a/lib/libgraph/graph/serializers/flowchart.ex
+++ b/lib/libgraph/graph/serializers/flowchart.ex
@@ -1,7 +1,7 @@
 defmodule Graph.Serializers.Flowchart do
-  @moduledoc """
-  This serializer converts a `Graph` to a [Mermaid Flowchart](https://mermaid.js.org/syntax/flowchart.html).
-  """
+  @moduledoc false
+
+  # This serializer converts a `Graph` to a [Mermaid Flowchart](https://mermaid.js.org/syntax/flowchart.html).
 
   use Graph.Serializer
   import Graph.Serializer

--- a/lib/libgraph/graph/utils.ex
+++ b/lib/libgraph/graph/utils.ex
@@ -1,5 +1,6 @@
 defmodule Graph.Utils do
   @moduledoc false
+
   @compile {:inline, [vertex_id: 1, edge_weight: 3]}
 
   @binary_heap_limit 64

--- a/lib/libgraph/priority_queue.ex
+++ b/lib/libgraph/priority_queue.ex
@@ -1,13 +1,14 @@
 defmodule PriorityQueue do
-  @moduledoc """
-  This module defines a priority queue datastructure, intended for use with graphs, as it prioritizes
-  lower priority values over higher priority values (ideal for priorities based on edge weights, etc.).
+  @moduledoc false
 
-  This implementation makes use of `:gb_trees` under the covers. It is also very fast, even for a very large
-  number of distinct priorities. Other priority queue implementations I've looked at are either slow when working
-  with large numbers of priorities, or restrict themselves to a specific number of allowed priorities, which is
-  why I've ended up writing my own.
-  """
+  # This module defines a priority queue datastructure, intended for use with graphs, as it prioritizes
+  # lower priority values over higher priority values (ideal for priorities based on edge weights, etc.).
+
+  # This implementation makes use of `:gb_trees` under the covers. It is also very fast, even for a very large
+  # number of distinct priorities. Other priority queue implementations I've looked at are either slow when working
+  # with large numbers of priorities, or restrict themselves to a specific number of allowed priorities, which is
+  # why I've ended up writing my own.
+
   defstruct priorities: nil
 
   @type t :: %__MODULE__{

--- a/mix.exs
+++ b/mix.exs
@@ -96,6 +96,30 @@ defmodule Hologram.MixProject do
         plt_core_path: Path.join(["priv", "plts", "core.plt"]),
         plt_local_path: Path.join(["priv", "plts", "project.plt"])
       ],
+      docs: [
+        api_reference: false,
+        authors: ["Bart Blast"],
+        groups_for_modules: [
+          Main: [
+            Hologram,
+            Hologram.Component,
+            Hologram.Component.Action,
+            Hologram.Component.Command,
+            Hologram.Page,
+            Hologram.Server
+          ],
+          Plug: [Hologram.Router, Hologram.Router.Helpers, Hologram.Socket],
+          UI: [Hologram.UI.Link, Hologram.UI.Runtime],
+          Errors: [
+            Hologram.AssetNotFoundError,
+            Hologram.CompileError,
+            Hologram.ParamError,
+            Hologram.TemplateSyntaxError
+          ]
+        ],
+        main: "Hologram",
+        source_ref: "master"
+      ],
       elixir: "~> 1.0",
       elixirc_options: [warnings_as_errors: true],
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -97,7 +97,6 @@ defmodule Hologram.MixProject do
         plt_local_path: Path.join(["priv", "plts", "project.plt"])
       ],
       docs: [
-        api_reference: false,
         authors: ["Bart Blast"],
         groups_for_modules: [
           Main: [
@@ -117,7 +116,6 @@ defmodule Hologram.MixProject do
             Hologram.TemplateSyntaxError
           ]
         ],
-        main: "Hologram",
         source_ref: "master"
       ],
       elixir: "~> 1.0",


### PR DESCRIPTION
closes: #162

Added suggested docs project configuration

Added @moduledoc false to all modules except:
`Hologram`
`Hologram.AssetNotFoundError`
`Hologram.CompileError`
`Hologram.Component`
`Hologram.Component.Action`
`Hologram.Component.Command`
`Hologram.Page`
`Hologram.ParamError`
`Hologram.Router`
`Hologram.Router.Helpers`
`Hologram.Server`
`Hologram.Socket`
`Hologram.TemplateSyntaxError`
`Hologram.UI.Link`
`Hologram.UI.Runtime`
`Mix.Tasks.Compile.Hologram`
`Mix.Tasks.Holo.Compiler.ExRuntimeMfas`
`Mix.Tasks.Holo.Compiler.PageExFunSizes`
`Mix.Tasks.Holo.Compiler.PageToMfaPaths`
`Mix.Tasks.Holo.Compiler.RuntimeToMfaPaths`
`Mix.Tasks.Holo.Routes`
`Mix.Tasks.Holo.Test.CheckFileNames`

Note: the compiler warns about references to types within below hidden modules:
`Hologram.Commons.Types`
`Hologram.Compiler.AST`

TODO: create git tags and change `source_ref` value to current app version