### PR TITLE
Fix reraise call

### DIFF
--- a/lib/hologram/page.ex
+++ b/lib/hologram/page.ex
@@ -113,9 +113,10 @@ defmodule Hologram.Page do
     String.to_existing_atom(value)
   rescue
     ArgumentError ->
-      reraise Hologram.ParamError,
-        message:
-          ~s/can't cast param "#{name}" with value #{KernelUtils.inspect(value)} to atom, because it's not an already existing atom/
+      message =
+        ~s/can't cast param "#{name}" with value #{KernelUtils.inspect(value)} to atom, because it's not an already existing atom/
+
+      reraise Hologram.ParamError, [message: message], __STACKTRACE__
   end
 
   defp cast_param(:atom, value, name) do


### PR DESCRIPTION
The `reraisee/2` function expects **stacktrace** as a second argument.
In order to pass error attributes we have to use `reraise/3` with **stacktrace** as a 3rd argument.

See documentation of  [reraise/3](https://hexdocs.pm/elixir/Kernel.html#reraise/3) for more information.