### PR TITLE
Update project version reference in project's docs configuration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@
 defmodule Hologram.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
 
   defp aliases do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,6 +2,8 @@
 defmodule Hologram.MixProject do
   use Mix.Project
 
+  @version "0.2.0"
+
   defp aliases do
     [
       eslint:
@@ -116,7 +118,7 @@ defmodule Hologram.MixProject do
             Hologram.TemplateSyntaxError
           ]
         ],
-        source_ref: "master"
+        source_ref: "v#{@version}"
       ],
       elixir: "~> 1.0",
       elixirc_options: [warnings_as_errors: true],
@@ -127,7 +129,7 @@ defmodule Hologram.MixProject do
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/bartblast/hologram",
       test_paths: ["test/elixir"],
-      version: "0.3.0",
+      version: @version,
       xref: [
         # These modules are used only in tests to test whether Hex.Solver's implementations
         # for Inspect and String.Chars protocols are excluded when building runtime and pages JavaScript files.


### PR DESCRIPTION
I made it easier by storing it in module attribute, so both `:version` and `:source_ref` in `:docs` uses same version.

If possible please move `v0.2.0` after merging this commit and update `hexdocs`, so the links to source code would use specified tag instead of `master`. However we can make it `v0.2.1` or so if needed to push docs.

Also looks like you have set `0.3.0` version in project configuration. I would recommend to change it right before creating new tag and pushing new release to `hex`.

**Edit**: I just found that you use `0.2.0` as latest release and `0.3.0` as latest tag and that's a bit confusing. Please let me know if I should change the module attribute value to `"0.3.0"` or we still want to work on `0.2.0`.