### PR TITLE
Emit :raw blocks from Parser

### DIFF
--- a/lib/hologram/template/dom.ex
+++ b/lib/hologram/template/dom.ex
@@ -30,10 +30,14 @@ defmodule Hologram.Template.DOM do
     {code, _last_tag_type} =
       Enum.reduce(tags, {"", nil}, fn tag, {code_acc, last_tag_type} ->
         current_tag_type = if is_tuple(tag), do: elem(tag, 0), else: tag
-        current_tag_code = render_code(tag)
-        new_code_acc = append_code(code_acc, current_tag_code, last_tag_type)
+        # :skip items are fully elided, as if they did not appear
+        case render_code(tag) do
+          :skip ->
+            {code_acc, last_tag_type}
 
-        {new_code_acc, current_tag_type}
+          current_tag_code ->
+            {append_code(code_acc, current_tag_code, last_tag_type), current_tag_type}
+        end
       end)
 
     "[#{code}]"
@@ -62,6 +66,17 @@ defmodule Hologram.Template.DOM do
     expr_str
     |> String.slice(1, String.length(expr_str) - 2)
     |> String.trim()
+  end
+
+  # `raw` blocks are useful only in the handling of template sources.
+  # `Parser` emits them so that such source can be reconstructed.
+  # They can be skipped in the building of the AST here.
+  defp render_code({:block_start, "raw"}) do
+    :skip
+  end
+
+  defp render_code({:block_end, "raw"}) do
+    :skip
   end
 
   defp render_code({:block_start, "else"}) do

--- a/lib/hologram/template/parser.ex
+++ b/lib/hologram/template/parser.ex
@@ -94,7 +94,7 @@ defmodule Hologram.Template.Parser do
             delimiter_stack: list(delimiter),
             node_type: :attribute | :block | :public_comment | :tag | :text,
             prev_status: Parser.status() | nil,
-            processed_tags: [],
+            processed_tags: list(Parser.parsed_tag()),
             processed_tokens: list(Tokenizer.token()),
             raw?: boolean,
             script?: boolean,
@@ -646,13 +646,17 @@ defmodule Hologram.Template.Parser do
   def parse_tokens(%{raw?: false} = context, :text, [{:symbol, "{%raw}"} = token | rest]) do
     context
     |> add_processed_token(token)
+    |> add_processed_tag({:block_start, "raw"})
     |> enable_raw_mode()
     |> parse_tokens(:text, rest)
   end
 
   def parse_tokens(%{raw?: true} = context, :text, [{:symbol, "{/raw}"} = token | rest]) do
     context
+    |> maybe_add_text_tag()
+    |> reset_token_buffer()
     |> add_processed_token(token)
+    |> add_processed_tag({:block_end, "raw"})
     |> disable_raw_mode()
     |> parse_tokens(:text, rest)
   end

--- a/test/elixir/hologram/template/dom_test.exs
+++ b/test/elixir/hologram/template/dom_test.exs
@@ -1175,6 +1175,41 @@ defmodule Hologram.Template.DOMTest do
     end
   end
 
+  describe "build_ast/1, raw block" do
+    test "literal tag elided" do
+      parse = [
+        {:block_start, "raw"},
+        {:block_end, "raw"}
+      ]
+
+      assert build_ast(parse) == []
+    end
+
+    test "text sections unmerged" do
+      parse = [
+        {:text, "before"},
+        {:block_start, "raw"},
+        {:text, "during"},
+        {:block_end, "raw"},
+        {:text, "after"}
+      ]
+
+      assert build_ast(parse) == [{:text, "before"}, {:text, "during"}, {:text, "after"}]
+    end
+
+    test "literal \"raw\" text passes safely index or out" do
+      parse = [
+        {:text, "raw"},
+        {:block_start, "raw"},
+        {:text, "raw"},
+        {:block_end, "raw"},
+        {:text, "raw"}
+      ]
+
+      assert build_ast(parse) == [{:text, "raw"}, {:text, "raw"}, {:text, "raw"}]
+    end
+  end
+
   test "build_ast/1, nested AST" do
     tags = [{:expression, "{(fn x -> [x | @acc] end).(@value)}"}]
 

--- a/test/elixir/hologram/template_test.exs
+++ b/test/elixir/hologram/template_test.exs
@@ -32,6 +32,14 @@ defmodule Hologram.TemplateTest do
       assert template.(%{}) == [{:element, "div", [], [text: "abc"]}]
     end
 
+    test "template with raw section" do
+      template = ~HOLO"""
+      {%raw}{%if true}Hologram{/if}{/raw}
+      """
+
+      assert template.(%{}) == [text: "{%if true}Hologram{/if}"]
+    end
+
     test "alias" do
       alias Aaa.Bbb.Ccc
       template = ~HOLO"<Ccc />"


### PR DESCRIPTION
These tags have no semantic value in the AST, so they are elided from that output.

Including them in the Parser output makes it possible to reconstruct the source more correctly from said parse.  This is valuable when dealing with the templates as source text, such as in the nascent Formatter module.

In the AST builder, `render_code` is updated to `:skip` "raw" tags. The most likely source of error here is handling a `[text: "raw"]` node. Tests are added to demonstrate probable correctness.

This `:skip` arrangement makes it easy to add any future "source-only" code handling, even though it is hard to see whence that would come.

A `wrap_in_raw` test helper is created to reduce the diff size of this change.  It demonstrates more clearly how the `raw` tag wraps (portions of) the output.  This can easily be revisited if it is felt that the more human-friendly option is having the literal output inline.