### PR TITLE
Erlang Binary functions

### DIFF
--- a/assets/js/erlang/binary.mjs
+++ b/assets/js/erlang/binary.mjs
@@ -638,6 +638,7 @@ const Erlang_Binary = {
       const msg = Type.isBitstring(subject)
         ? "is a bitstring (expected a binary)"
         : "not a binary";
+
       Interpreter.raiseArgumentError(Interpreter.buildArgumentErrorMsg(1, msg));
     }
 
@@ -723,7 +724,8 @@ const Erlang_Binary = {
   // Start split/2
   "split/2": (subject, pattern) => {
     const patternObj = Matcher.create(pattern);
-    return patternObj.split(subject, Type.list([]));  },
+    return patternObj.split(subject, Type.list([]));
+  },
   // End split/2
   // Deps: []
 

--- a/test/javascript/erlang/binary_test.mjs
+++ b/test/javascript/erlang/binary_test.mjs
@@ -9,6 +9,7 @@ import {
 
 import Bitstring from "../../../assets/js/bitstring.mjs";
 import Erlang_Binary from "../../../assets/js/erlang/binary.mjs";
+import Interpreter from "../../../assets/js/interpreter.mjs";
 import Type from "../../../assets/js/type.mjs";
 
 defineGlobalErlangAndElixirModules();


### PR DESCRIPTION
https://github.com/bartblast/hologram/issues/355

The scope of the issue was for `:binary.split/2` and `:binary.split/3`
- This required creating `:binary.compile_pattern/1` and implementing the existing matching algorithms, which was the bulk of the actual work to get the initial scope finished.
- Because those matching algorithms were finished, it made adding `:binary.match/2`, `:binary.match/3`, `:binary.matches/2`, `:binary.matches/3`, `:binary.replace/3`, and `:binary.replace/4` became relatively easy to implement as they also rely on those algoithms for the heavy lifting, and they are consequently included in this pull request.