### PR TITLE
Port :lists.all/2 to JS

### DIFF
--- a/assets/js/erlang/lists.mjs
+++ b/assets/js/erlang/lists.mjs
@@ -278,6 +278,45 @@ const Erlang_Lists = {
   },
   // End sort/1
   // Deps: []
+
+  // Start all/2
+  "all/2": (fun, list) => {
+    if (!Type.isAnonymousFunction(fun) || fun.arity !== 1) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":lists.all/2", [fun, list]),
+      );
+    }
+
+    if (!Type.isList(list)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(2, "not a list"),
+      );
+    }
+
+    if (!Type.isProperList(list)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(2, "not a proper list"),
+      );
+    }
+
+    return Type.boolean(
+      list.data.every((elem) => {
+        const result = Interpreter.callAnonymousFunction(fun, [elem]);
+
+        if (!Type.isBoolean(result)) {
+          Interpreter.raiseErlangError(
+            Interpreter.buildErlangErrorMsg(
+              `{:bad_filter, ${Interpreter.inspect(result)}}`,
+            ),
+          );
+        }
+
+        return Type.isTrue(result);
+      }),
+    );
+  },
+  // End all/2
+  // Deps: []
 };
 
 export default Erlang_Lists;


### PR DESCRIPTION
## Summary
Implements the `:lists.all/2` function for the JavaScript runtime, matching Erlang's `lists:all/2` behavior.

## Changes
- ✅ Added `all/2` implementation in `assets/js/erlang/lists.mjs`
- ✅ Added 11 comprehensive JavaScript tests in `test/javascript/erlang/lists_test.mjs`
- ✅ Added 11 comprehensive Elixir consistency tests in `test/elixir/hologram/ex_js_consistency/erlang/lists_test.exs`

## Implementation Details
- Validates that the predicate function returns a boolean (raises `ErlangError` with `{:bad_filter, value}` if not)
- Uses `Type.isTrue()` to properly check boolean values
- Handles all error cases: invalid function, wrong arity, invalid list, improper list, non-boolean returns
- Returns `true` for empty lists (vacuous truth)
- Follows the same patterns as `filter/2` and other list functions

