### PR TITLE
Port :sets.from_list/2 and :sets.new/1 to JS

### DIFF
--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -39,6 +39,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:maps, :get, 2}, {:maps, :get, 3}},
     {{:maps, :update, 3}, {:maps, :is_key, 2}},
     {{:maps, :update, 3}, {:maps, :put, 3}},
+    {{:sets, :_validate_opts, 3}, {:lists, :keyfind, 3}},
     {{:sets, :from_list, 2}, {:maps, :from_keys, 2}},
     {{:sets, :from_list, 2}, {:sets, :_validate_opts, 3}},
     {{:sets, :new, 1}, {:sets, :_validate_opts, 3}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
@@ -43,6 +43,16 @@ defmodule Hologram.ExJsConsistency.Erlang.SetsTest do
       result = :sets.new([{:version, 2}])
       assert result == %{}
     end
+
+    test "ignores invalid option keys (doesn't raise)" do
+      :sets.new([{:invalid, 2}])
+    end
+
+    test "raises CaseClauseError when version is invalid" do
+      assert_raise CaseClauseError, fn ->
+        :sets.new([{:version, 3}])
+      end
+    end
   end
 
   describe "to_list/1" do

--- a/test/javascript/erlang/sets_test.mjs
+++ b/test/javascript/erlang/sets_test.mjs
@@ -91,6 +91,23 @@ describe("Erlang_Sets", () => {
       assert.deepStrictEqual(result, expected);
     });
 
+    it("creates a new empty set with empty opts (defaults to version 2)", () => {
+      const result = new_1(Type.list([]));
+      const expected = Type.map([]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("ignores invalid option keys", () => {
+      const opts = Type.list([
+        Type.tuple([Type.atom("invalid"), Type.integer(2)]),
+      ]);
+      const result = new_1(opts);
+      const expected = Type.map([]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
     it("raises FunctionClauseError when opts is not a list", () => {
       const opts = Type.atom("invalid");
 
@@ -101,7 +118,7 @@ describe("Erlang_Sets", () => {
       );
     });
 
-    it("raises HologramInterpreterError when version is not 2", () => {
+    it("raises HologramInterpreterError when version is 1", () => {
       const opts = Type.list([
         Type.tuple([Type.atom("version"), Type.integer(1)]),
       ]);
@@ -110,6 +127,17 @@ describe("Erlang_Sets", () => {
         () => new_1(opts),
         HologramInterpreterError,
         ":sets version 1 is not supported in Hologram, use [{:version, 2}] option",
+      );
+    });
+
+    it("raises CaseClauseError when version is invalid", () => {
+      const version = Type.integer(3);
+      const opts = Type.list([Type.tuple([Type.atom("version"), version])]);
+
+      assertBoxedError(
+        () => new_1(opts),
+        "CaseClauseError",
+        "no case clause matching: " + Interpreter.inspect(version),
       );
     });
   });


### PR DESCRIPTION
A few remarks : 

- In test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs, I define a SetsTestHelper module normalizing version discrepancies. It is only used by functions that take in the version argument. Is that alright for you ?
- I did not have a great idea yet on how to mimic the rejection of version 1 sets elixir-side in the consistency tests, and left a warning in test/javascript/erlang/sets_test.mjs

Feel free to ask for any relevant changes and I will proceed working on them.

see #296 

Best,
Lucas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added set creation from lists and an explicit new(empty) set constructor with option validation.
  * Exposed clearer versioned options handling (supports version 2; rejects unsupported versions).

* **Bug Fixes**
  * Improved option validation and more precise error reporting for invalid or non-list options.

* **Tests**
  * Expanded JavaScript and Elixir tests covering construction, duplicates, empty sets, and error cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->