### PR TITLE
Port :sets.intersection/2 to JS

### DIFF
--- a/assets/js/erlang/sets.mjs
+++ b/assets/js/erlang/sets.mjs
@@ -10,6 +10,20 @@ export function subtract(set1, set2) {
 // End subtract/2
 // Deps: []
 
+// Start intersection/2
+export function intersection(set1, set2) {
+  // Sets are stored internally as JS Maps representing Erlang sets
+  const result = new Map();
+  for (const elem of set1.keys()) {
+    if (set2.has(elem)) {
+      result.set(elem, true);
+    }
+  }
+  return result;
+}
+// End intersection/2
+// Deps: []
+
 // Start union/2
 export function union(set1, set2) {
   // Sets are stored internally as JS Maps representing Erlang sets
@@ -23,6 +37,7 @@ export function union(set1, set2) {
 // Deps: []
 
 export default {
+  "intersection/2": intersection,
   "subtract/2": subtract,
   "union/2": union,
 };

--- a/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
@@ -74,6 +74,87 @@ defmodule Hologram.ExJsConsistency.Erlang.SetsTest do
     end
   end
 
+  describe "intersection/2" do
+    test "returns common elements from both sets" do
+      set1 = :sets.from_list([1, 2, 3])
+      set2 = :sets.from_list([2, 3, 4])
+
+      result = :sets.intersection(set1, set2)
+
+      assert result
+             |> :sets.to_list()
+             |> Enum.sort() == [2, 3]
+    end
+
+    test "returns empty set when sets have no common elements" do
+      set1 = :sets.from_list([1, 2])
+      set2 = :sets.from_list([3, 4])
+
+      result = :sets.intersection(set1, set2)
+
+      assert :sets.size(result) == 0
+    end
+
+    test "returns a new set without modifying the original sets" do
+      set1 = :sets.from_list([1, 2])
+      set2 = :sets.from_list([2, 3])
+
+      result = :sets.intersection(set1, set2)
+
+      # Original sets should remain unchanged
+      assert set1
+             |> :sets.to_list()
+             |> Enum.sort() == [1, 2]
+
+      assert set2
+             |> :sets.to_list()
+             |> Enum.sort() == [2, 3]
+
+      # Result should only contain common element
+      assert result
+             |> :sets.to_list()
+             |> Enum.sort() == [2]
+    end
+
+    test "returns empty set when first set is empty" do
+      set1 = :sets.new()
+      set2 = :sets.from_list([1, 2])
+
+      result = :sets.intersection(set1, set2)
+
+      assert :sets.size(result) == 0
+    end
+
+    test "returns empty set when second set is empty" do
+      set1 = :sets.from_list([1, 2])
+      set2 = :sets.new()
+
+      result = :sets.intersection(set1, set2)
+
+      assert :sets.size(result) == 0
+    end
+
+    test "returns empty set when both sets are empty" do
+      set1 = :sets.new()
+      set2 = :sets.new()
+
+      result = :sets.intersection(set1, set2)
+
+      assert :sets.size(result) == 0
+    end
+
+    test "returns same elements when sets are identical" do
+      set1 = :sets.from_list([1, 2])
+      set2 = :sets.from_list([1, 2])
+
+      result = :sets.intersection(set1, set2)
+
+      assert result
+             |> :sets.to_list()
+             |> Enum.sort() == [1, 2]
+    end
+  end
+
   describe "union/2" do
     test "combines elements from both sets" do
       set1 = :sets.from_list([1, 2])

--- a/test/javascript/erlang/sets.test.mjs
+++ b/test/javascript/erlang/sets.test.mjs
@@ -89,6 +89,122 @@ describe("Erlang_Sets", () => {
     });
   });
 
+  describe("intersection/2", () => {
+    const intersection = Erlang_Sets["intersection/2"];
+
+    it("returns common elements from both sets", () => {
+      const set1 = new Map([
+        [1, true],
+        [2, true],
+        [3, true],
+      ]);
+      const set2 = new Map([
+        [2, true],
+        [3, true],
+        [4, true],
+      ]);
+
+      const result = intersection(set1, set2);
+
+      assert.strictEqual(result.has(1), false);
+      assert.strictEqual(result.has(2), true);
+      assert.strictEqual(result.has(3), true);
+      assert.strictEqual(result.has(4), false);
+      assert.strictEqual(result.size, 2);
+    });
+
+    it("returns empty set when sets have no common elements", () => {
+      const set1 = new Map([
+        [1, true],
+        [2, true],
+      ]);
+      const set2 = new Map([
+        [3, true],
+        [4, true],
+      ]);
+
+      const result = intersection(set1, set2);
+
+      assert.strictEqual(result.size, 0);
+    });
+
+    it("returns a new set without modifying the original sets", () => {
+      const set1 = new Map([
+        [1, true],
+        [2, true],
+      ]);
+      const set2 = new Map([
+        [2, true],
+        [3, true],
+      ]);
+
+      const result = intersection(set1, set2);
+
+      // Original sets should remain unchanged
+      assert.strictEqual(set1.has(1), true);
+      assert.strictEqual(set1.has(2), true);
+      assert.strictEqual(set1.size, 2);
+
+      assert.strictEqual(set2.has(2), true);
+      assert.strictEqual(set2.has(3), true);
+      assert.strictEqual(set2.size, 2);
+
+      // Result should only contain common element
+      assert.strictEqual(result.has(2), true);
+      assert.strictEqual(result.size, 1);
+    });
+
+    it("returns empty set when first set is empty", () => {
+      const set1 = new Map();
+      const set2 = new Map([
+        [1, true],
+        [2, true],
+      ]);
+
+      const result = intersection(set1, set2);
+
+      assert.strictEqual(result.size, 0);
+    });
+
+    it("returns empty set when second set is empty", () => {
+      const set1 = new Map([
+        [1, true],
+        [2, true],
+      ]);
+      const set2 = new Map();
+
+      const result = intersection(set1, set2);
+
+      assert.strictEqual(result.size, 0);
+    });
+
+    it("returns empty set when both sets are empty", () => {
+      const set1 = new Map();
+      const set2 = new Map();
+
+      const result = intersection(set1, set2);
+
+      assert.strictEqual(result.size, 0);
+    });
+
+    it("returns same elements when sets are identical", () => {
+      const set1 = new Map([
+        [1, true],
+        [2, true],
+      ]);
+      const set2 = new Map([
+        [1, true],
+        [2, true],
+      ]);
+
+      const result = intersection(set1, set2);
+
+      assert.strictEqual(result.has(1), true);
+      assert.strictEqual(result.has(2), true);
+      assert.strictEqual(result.size, 2);
+    });
+  });
+
   describe("union/2", () => {
     const union = Erlang_Sets["union/2"];
 


### PR DESCRIPTION
This PR ports the `:sets.intersection/2` function to the JavaScript runtime.

## Changes
- Implemented `:sets.intersection/2` in [assets/js/erlang/sets.mjs](cci:7://file:///media/amrit/SSDAmrit/Builds/Elixir/hologram/assets/js/erlang/sets.mjs:0:0-0:0) using JavaScript `Map`.
- Added 7 JavaScript unit tests in [test/javascript/erlang/sets.test.mjs](cci:7://file:///media/amrit/SSDAmrit/Builds/Elixir/hologram/test/javascript/erlang/sets.test.mjs:0:0-0:0).
- Added 7 Elixir consistency tests in [test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs](cci:7://file:///media/amrit/SSDAmrit/Builds/Elixir/hologram/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs:0:0-0:0).

## Verification
- All JavaScript unit tests passed (7/7).
- All Elixir consistency tests passed (7/7).
- Ran `mix credo --strict` with no issues.