### PR TITLE
Port :erlang.bsl/2 to JS

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -538,6 +538,28 @@ const Erlang = {
   // End bit_size/1
   // Deps: []
 
+  // Start bsl/2
+  "bsl/2": (integer, shift) => {
+    if (!Type.isInteger(integer) || !Type.isInteger(shift)) {
+      const arg1 = Interpreter.inspect(integer);
+      const arg2 = Interpreter.inspect(shift);
+
+      Interpreter.raiseArithmeticError(`Bitwise.bsl(${arg1}, ${arg2})`);
+    }
+
+    const integerValue = integer.value;
+    const shiftValue = shift.value;
+
+    if (shiftValue < 0n) {
+      // Erlang's bsl with negative shift is equivalent to bsr with positive shift
+      return Type.integer(integerValue >> -shiftValue);
+    } else {
+      return Type.integer(integerValue << shiftValue);
+    }
+  },
+  // End bsl/2
+  // Deps: []
+
   // Start bsr/2
   "bsr/2": (integer, shift) => {
     if (!Type.isInteger(integer) || !Type.isInteger(shift)) {

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -1837,6 +1837,63 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "bsl/2" do
+    test "common usage" do
+      # 1 = 0b00000001, 16 = 0b00010000
+      assert :erlang.bsl(1, 4) == 16
+    end
+
+    test "zero shift" do
+      assert :erlang.bsl(255, 0) == 255
+    end
+
+    test "shift right via negative shift" do
+      # 16 = 0b00010000, 8 = 0b00001000
+      assert :erlang.bsl(16, -1) == 8
+    end
+
+    test "negative keeps sign bit" do
+      # -8 = -0b00001000, -16 = -0b00010000
+      assert :erlang.bsl(-8, 1) == -16
+    end
+
+    test "above JS Number.MAX_SAFE_INTEGER" do
+      # Number.MAX_SAFE_INTEGER == 9_007_199_254_740_991
+      #  9_007_199_254_740_992 = 0b100000000000000000000000000000000000000000000000000000
+      # 18_014_398_509_481_984 = 0b1000000000000000000000000000000000000000000000000000000
+      assert :erlang.bsl(9_007_199_254_740_992, 1) == 18_014_398_509_481_984
+    end
+
+    test "below JS Number.MIN_SAFE_INTEGER" do
+      # Number.MIN_SAFE_INTEGER == -9_007_199_254_740_991
+      #  -9_007_199_254_740_992 = -0b100000000000000000000000000000000000000000000000000000
+      # -18_014_398_509_481_984 = -0b1000000000000000000000000000000000000000000000000000000
+      assert :erlang.bsl(-9_007_199_254_740_992, 1) == -18_014_398_509_481_984
+    end
+
+    test "shift beyond size for positive integer" do
+      # 255 = 0b1111111
+      assert :erlang.bsl(255, 9) == 130_560
+    end
+
+    test "shift beyond size for negative integer" do
+      # -127 = -0b1111111
+      assert :erlang.bsl(-127, 8) == -32512
+    end
+
+    test "raises ArithmeticError if the first argument is not an integer" do
+      assert_error ArithmeticError,
+                   "bad argument in arithmetic expression: Bitwise.bsl(1.0, 2)",
+                   {:erlang, :bsl, [1.0, 2]}
+    end
+
+    test "raises ArithmeticError if the second argument is not an integer" do
+      assert_error ArithmeticError,
+                   "bad argument in arithmetic expression: Bitwise.bsl(1, 2.0)",
+                   {:erlang, :bsl, [1, 2.0]}
+    end
+  end
+
   describe "bsr/2" do
     test "common usage" do
       # 16 = 0b00010000, 8 = 0b00001000

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -2558,6 +2558,93 @@ describe("Erlang", () => {
     });
   });
 
+  describe("bsl/2", () => {
+    const testedFun = Erlang["bsl/2"];
+
+    it("common usage", () => {
+      // 1 = 0b00000001, 16 = 0b00010000
+      assert.deepStrictEqual(
+        testedFun(Type.integer(1), Type.integer(4)),
+        Type.integer(16),
+      );
+    });
+
+    it("zero shift", () => {
+      assert.deepStrictEqual(
+        testedFun(Type.integer(255), Type.integer(0)),
+        Type.integer(255),
+      );
+    });
+
+    it("shift right via negative shift", () => {
+      // 16 = 0b00010000, 8 = 0b00001000
+      assert.deepStrictEqual(
+        testedFun(Type.integer(16), Type.integer(-1)),
+        Type.integer(8),
+      );
+    });
+
+    it("negative keeps sign bit", () => {
+      // -8 = -0b00001000, -16 = -0b00010000
+      assert.deepStrictEqual(
+        testedFun(Type.integer(-8), Type.integer(1)),
+        Type.integer(-16),
+      );
+    });
+
+    it("above JS Number.MAX_SAFE_INTEGER", () => {
+      // Number.MAX_SAFE_INTEGER == 9_007_199_254_740_991
+      //  9_007_199_254_740_992 = 0b100000000000000000000000000000000000000000000000000000
+      // 18_014_398_509_481_984 = 0b1000000000000000000000000000000000000000000000000000000
+      assert.deepStrictEqual(
+        testedFun(Type.integer(9_007_199_254_740_992n), Type.integer(1)),
+        Type.integer(18_014_398_509_481_984n),
+      );
+    });
+
+    it("below JS Number.MIN_SAFE_INTEGER", () => {
+      // Number.MIN_SAFE_INTEGER == -9_007_199_254_740_991
+      //  -9_007_199_254_740_992 = -0b100000000000000000000000000000000000000000000000000000
+      // -18_014_398_509_481_984 = -0b1000000000000000000000000000000000000000000000000000000
+      assert.deepStrictEqual(
+        testedFun(Type.integer(-9_007_199_254_740_992n), Type.integer(1)),
+        Type.integer(-18_014_398_509_481_984n),
+      );
+    });
+
+    it("shift beyond size for positive integer", () => {
+      // 255 = 0b1111111
+      assert.deepStrictEqual(
+        testedFun(Type.integer(255), Type.integer(9)),
+        Type.integer(130560),
+      );
+    });
+
+    it("shift beyond size for negative integer", () => {
+      // -127 = -0b1111111
+      assert.deepStrictEqual(
+        testedFun(Type.integer(-127), Type.integer(8)),
+        Type.integer(-32512),
+      );
+    });
+
+    it("raises ArithmeticError if the first argument is not an integer", () => {
+      assertBoxedError(
+        () => testedFun(Type.float(1.0), Type.integer(2)),
+        "ArithmeticError",
+        "bad argument in arithmetic expression: Bitwise.bsl(1.0, 2)",
+      );
+    });
+
+    it("raises ArithmeticError if the second argument is not an integer", () => {
+      assertBoxedError(
+        () => testedFun(Type.integer(1), Type.float(2.0)),
+        "ArithmeticError",
+        "bad argument in arithmetic expression: Bitwise.bsl(1, 2.0)",
+      );
+    });
+  });
+
   describe("bsr/2", () => {
     const testedFun = Erlang["bsr/2"];
 


### PR DESCRIPTION
Closes #475 

FWIW, I had to save `test/javascript/erlang/erlang_test.mjs` without formatting. My editor was formatting the code differently than the entire rest of the file. I didn't look into how formatting works for this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added left shift bit operation with full integer validation.

* **Improvements**
  * Enhanced right shift bit operation to properly handle negative shift values.

* **Tests**
  * Added comprehensive test coverage for bit shift operations including edge cases and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->