### PR TITLE
Port :sets.is_element/2 to JS

### DIFF
--- a/assets/js/erlang/sets.mjs
+++ b/assets/js/erlang/sets.mjs
@@ -66,6 +66,22 @@ const Erlang_Sets = {
   // End from_list/2
   // Deps: [:maps.from_keys/2, :sets._validate_opts/1]
 
+  // Start is_element/2
+  "is_element/2": (element, set) => {
+    if (!Type.isMap(set)) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":sets.is_element/2", [
+          element,
+          set,
+        ]),
+      );
+    }
+
+    return Erlang_Maps["is_key/2"](element, set);
+  },
+  // End is_element/2
+  // Deps: [:maps.is_key/2]
+
   // Start new/1
   "new/1": (opts) => {
     Erlang_Sets["_validate_opts/1"](opts);

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -42,6 +42,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:sets, :_validate_opts, 1}, {:lists, :keyfind, 3}},
     {{:sets, :from_list, 2}, {:maps, :from_keys, 2}},
     {{:sets, :from_list, 2}, {:sets, :_validate_opts, 1}},
+    {{:sets, :is_element, 2}, {:maps, :is_key, 2}},
     {{:sets, :new, 1}, {:sets, :_validate_opts, 1}},
     {{:sets, :to_list, 1}, {:maps, :keys, 1}},
     {{:unicode, :characters_to_binary, 1}, {:unicode, :characters_to_binary, 3}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
@@ -73,6 +73,31 @@ defmodule Hologram.ExJsConsistency.Erlang.SetsTest do
     end
   end
 
+  describe "is_element/2" do
+    test "returns true if element is in the set" do
+      set = :sets.from_list([1, 2, 3], [{:version, 2}])
+      assert :sets.is_element(2, set) == true
+    end
+
+    test "returns false if element is not in the set" do
+      set = :sets.from_list([1, 2, 3], [{:version, 2}])
+      assert :sets.is_element(42, set) == false
+    end
+
+    test "returns false for empty set" do
+      set = :sets.new([{:version, 2}])
+      assert :sets.is_element(:any, set) == false
+    end
+
+    test "raises FunctionClauseError if argument is not a set" do
+      expected_msg = build_function_clause_error_msg(":sets.is_element/2", [:elem, :not_a_set])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :sets.is_element(:elem, :not_a_set)
+      end
+    end
+  end
+
   describe "new/1" do
     setup do
       [opts: [{:version, 2}]]

--- a/test/javascript/erlang/sets_test.mjs
+++ b/test/javascript/erlang/sets_test.mjs
@@ -147,6 +147,44 @@ describe("Erlang_Sets", () => {
     });
   });
 
+  describe("is_element/2", () => {
+    const is_element_2 = Erlang_Sets["is_element/2"];
+
+    it("returns true if element is in the set", () => {
+      const result = is_element_2(integer2, set123);
+
+      assert.deepStrictEqual(result, Type.boolean(true));
+    });
+
+    it("returns false if element is not in the set", () => {
+      const integer42 = Type.integer(42);
+      const result = is_element_2(integer42, set123);
+
+      assert.deepStrictEqual(result, Type.boolean(false));
+    });
+
+    it("returns false for empty set", () => {
+      const emptySet = Type.map();
+      const result = is_element_2(Type.atom("any"), emptySet);
+
+      assert.deepStrictEqual(result, Type.boolean(false));
+    });
+
+    it("raises FunctionClauseError if argument is not a set", () => {
+      const elem = Type.atom("elem");
+      const notASet = Type.atom("not_a_set");
+
+      assertBoxedError(
+        () => is_element_2(elem, notASet),
+        "FunctionClauseError",
+        Interpreter.buildFunctionClauseErrorMsg(":sets.is_element/2", [
+          elem,
+          notASet,
+        ]),
+      );
+    });
+  });
+
   describe("new/1", () => {
     const new_1 = Erlang_Sets["new/1"];
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added is_element/2 to check membership in sets with input validation and clear error reporting.

* **Tests**
  * Added comprehensive tests for is_element/2 covering present/absent elements, empty sets, and invalid-argument errors across implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

References issue #297