### PR TITLE
Port :lists.mapfoldl/3 to JS

### DIFF
--- a/assets/js/erlang/lists.mjs
+++ b/assets/js/erlang/lists.mjs
@@ -287,6 +287,62 @@ const Erlang_Lists = {
   // End map/2
   // Deps: []
 
+  // Start mapfoldl/3
+  "mapfoldl/3": function (fun, initialAcc, list) {
+    if (!Type.isAnonymousFunction(fun) || fun.arity !== 2) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":lists.mapfoldl/3", arguments),
+      );
+    }
+
+    if (!Type.isList(list)) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(
+          ":lists.mapfoldl_1/3",
+          arguments,
+        ),
+      );
+    }
+
+    const isProperList = Type.isProperList(list);
+    const elementsCount = isProperList
+      ? list.data.length
+      : Math.max(list.data.length - 1, 0);
+
+    let acc = initialAcc;
+    const mappedElements = [];
+
+    for (let i = 0; i < elementsCount; ++i) {
+      const result = Interpreter.callAnonymousFunction(fun, [
+        list.data[i],
+        acc,
+      ]);
+
+      if (!Type.isTuple(result) || result.data.length !== 2) {
+        Interpreter.raiseMatchError(Interpreter.buildMatchErrorMsg(result));
+      }
+
+      mappedElements.push(result.data[0]);
+      acc = result.data[1];
+    }
+
+    if (!isProperList) {
+      const improperTail = list.data.at(-1);
+
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":lists.mapfoldl_1/3", [
+          fun,
+          acc,
+          improperTail,
+        ]),
+      );
+    }
+
+    return Type.tuple([Type.list(mappedElements), acc]);
+  },
+  // End mapfoldl/3
+  // Deps: []
+
   // Start member/2
   "member/2": (elem, list) => {
     if (!Type.isList(list)) {

--- a/test/javascript/erlang/lists_test.mjs
+++ b/test/javascript/erlang/lists_test.mjs
@@ -1128,6 +1128,155 @@ describe("Erlang_Lists", () => {
     });
   });
 
+  describe("mapfoldl/3", () => {
+    const fun = Type.anonymousFunction(
+      2,
+      [
+        {
+          params: (_context) => [
+            Type.variablePattern("elem"),
+            Type.variablePattern("acc"),
+          ],
+          guards: [],
+          body: (context) => {
+            return Type.tuple([
+              Erlang["*/2"](context.vars.elem, Type.integer(10)),
+              Erlang["+/2"](context.vars.acc, context.vars.elem),
+            ]);
+          },
+        },
+      ],
+      contextFixture(),
+    );
+
+    const mapfoldl = Erlang_Lists["mapfoldl/3"];
+    const acc = integer0;
+
+    it("mapfolds empty list", () => {
+      const result = mapfoldl(fun, acc, emptyList);
+
+      const expected = Type.tuple([emptyList, acc]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("mapfolds non-empty list", () => {
+      const list = Type.list([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const result = mapfoldl(fun, acc, list);
+
+      const expected = Type.tuple([
+        Type.list([Type.integer(10), Type.integer(20), Type.integer(30)]),
+        Type.integer(6),
+      ]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("raises FunctionClauseError if the first argument is not an anonymous function", () => {
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.mapfoldl/3",
+        [Type.atom("abc"), acc, emptyList],
+      );
+
+      assertBoxedError(
+        () => mapfoldl(Type.atom("abc"), acc, emptyList),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+
+    it("raises FunctionClauseError if the first argument is an anonymous function with arity different than 2", () => {
+      const funArity1 = Type.anonymousFunction(
+        1,
+        [
+          {
+            params: (_context) => [Type.variablePattern("elem")],
+            guards: [],
+            body: (context) => {
+              return context.vars.elem;
+            },
+          },
+        ],
+        contextFixture(),
+      );
+
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.mapfoldl/3",
+        [funArity1, acc, emptyList],
+      );
+
+      assertBoxedError(
+        () => mapfoldl(funArity1, acc, emptyList),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+
+    it("raises FunctionClauseError if the third argument is not a list", () => {
+      const invalidArg = Type.atom("abc");
+
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.mapfoldl_1/3",
+        [fun, acc, invalidArg],
+      );
+
+      assertBoxedError(
+        () => mapfoldl(fun, acc, invalidArg),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+
+    it("raises FunctionClauseError if the third argument is an improper list", () => {
+      const list = Type.improperList([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.mapfoldl_1/3",
+        [fun, Type.integer(3), Type.integer(3)],
+      );
+
+      assertBoxedError(
+        () => mapfoldl(fun, acc, list),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+
+    it("raises MatchError if the anonymous function does not return a 2-element tuple", () => {
+      const invalidFun = Type.anonymousFunction(
+        2,
+        [
+          {
+            params: (_context) => [
+              Type.variablePattern("elem"),
+              Type.variablePattern("acc"),
+            ],
+            guards: [],
+            body: (context) => {
+              return Erlang["+/2"](context.vars.elem, context.vars.acc);
+            },
+          },
+        ],
+        contextFixture(),
+      );
+
+      assertBoxedError(
+        () => mapfoldl(invalidFun, acc, properList),
+        "MatchError",
+        Interpreter.buildMatchErrorMsg(integer1),
+      );
+    });
+  });
+
   describe("member/2", () => {
     const member = Erlang_Lists["member/2"];
 


### PR DESCRIPTION
Closes #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mapfoldl/3 to Erlang Lists — maps elements while accumulating a result, returning {mapped_list, final_acc}.

* **Tests**
  * Added comprehensive tests for mapfoldl/3 covering empty/non-empty lists, anonymous-function arity/type validation, improper-list errors, and non-2-tuple return handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->