### PR TITLE
Port :maps.merge_with/3 to JS

### DIFF
--- a/assets/js/erlang/maps.mjs
+++ b/assets/js/erlang/maps.mjs
@@ -204,17 +204,16 @@ const Erlang_Maps = {
       Interpreter.raiseBadMapError(map2);
     }
 
-    const resultMap = Utils.shallowCloneObject(map1);
-    resultMap.data = Utils.shallowCloneObject(map1.data);
+    const resultMap = Type.cloneMap(map1);
 
     Object.values(map2.data).forEach(([key, value2]) => {
       const encodedKey = Type.encodeMapKey(key);
-      const value1 = resultMap.data[encodedKey];
+      const value1Entry = resultMap.data[encodedKey];
       const newValue =
-        value1 !== undefined
+        value1Entry !== undefined
           ? Interpreter.callAnonymousFunction(combiner, [
               key,
-              value1[1],
+              value1Entry[1],
               value2,
             ])
           : value2;

--- a/test/elixir/hologram/ex_js_consistency/erlang/maps_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/maps_test.exs
@@ -316,6 +316,18 @@ defmodule Hologram.ExJsConsistency.Erlang.MapsTest do
       assert result == %{:atom_key => [1, 10], "string_key" => 2.5, 123 => "value"}
     end
 
+    test "doesn't mutate its arguments", %{combiner: combiner} do
+      map_1 = %{a: 1, b: 2}
+      map_2 = %{b: 3, c: 4}
+      map_1_copy = Map.new(map_1)
+      map_2_copy = Map.new(map_2)
+
+      _result = :maps.merge_with(combiner, map_1, map_2)
+
+      assert map_1 == map_1_copy
+      assert map_2 == map_2_copy
+    end
+
     test "raises ArgumentError if the first argument is not an anonymous function" do
       assert_error ArgumentError,
                    build_argument_error_msg(1, "not a fun that takes three arguments"),

--- a/test/javascript/erlang/maps_test.mjs
+++ b/test/javascript/erlang/maps_test.mjs
@@ -700,6 +700,26 @@ describe("Erlang_Maps", () => {
       assert.deepStrictEqual(result, expected);
     });
 
+    it("doesn't mutate its arguments", () => {
+      const map1 = Type.map([
+        [atomA, integer1],
+        [atomB, integer2],
+      ]);
+
+      const map2 = Type.map([
+        [atomB, Type.integer(3)],
+        [atomC, Type.integer(4)],
+      ]);
+
+      const map1Keys = Object.keys(map1.data).sort();
+      const map2Keys = Object.keys(map2.data).sort();
+
+      merge_with(combiner, map1, map2);
+
+      assert.deepStrictEqual(Object.keys(map1.data).sort(), map1Keys);
+      assert.deepStrictEqual(Object.keys(map2.data).sort(), map2Keys);
+    });
+
     it("raises ArgumentError if the first argument is not an anonymous function", () => {
       const map1 = Type.map([[atomA, integer1]]);
       const map2 = Type.map([[atomB, integer2]]);


### PR DESCRIPTION
Closes #499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a map-merge operation that accepts a user-provided 3-arity combiner to resolve overlapping keys; non-overlapping keys use the second map's values and inputs are not mutated.

* **Tests**
  * Added comprehensive test coverage for overlapping/non-overlapping keys, empty maps, mixed data types, combiner behaviors, non-mutation, and argument/error validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->