### PR TITLE
Add `sa` mix alias for static analysis

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,19 @@ defmodule Hologram.MixProject do
         "cmd assets/node_modules/.bin/prettier '*.yml' '.github/**' 'assets/*.json' 'assets/*.mjs' 'assets/js/**' 'benchmarks/javascript/**' 'scripts/**' 'test/javascript/**' --config 'assets/.prettierrc.json' --write",
       "format.js.check":
         "cmd assets/node_modules/.bin/prettier '*.yml' '.github/**' 'assets/*.json' 'assets/*.mjs' 'assets/js/**' 'benchmarks/javascript/**' 'scripts/**' 'test/javascript/**' --check --config 'assets/.prettierrc.json' --no-error-on-unmatched-pattern",
+      sa: [
+        "format --check-formatted",
+        "format.js.check",
+        "cmd cd test/features && mix format --check-formatted",
+        "credo",
+        "dialyzer",
+        "doctor",
+        "sobelow --config",
+        "deps.audit",
+        "eslint",
+        "deps.unlock --check-unused",
+        "holo.test.check_file_names test/elixir/hologram"
+      ],
       setup: [
         "deps.get",
         "cmd --cd assets npm install",
@@ -99,6 +112,7 @@ defmodule Hologram.MixProject do
 
   def preferred_cli_env do
     [
+      sa: :test,
       t: :test,
       "test.js": :test
     ]


### PR DESCRIPTION
A simplified way to run all of the included static analysis tasks for this repository.  It ought to make it more ergonomic for contributors to avoid back and forth with the CI checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new development alias group for running multiple quality-check and analysis tasks including code formatting checks, linting, type checking, code analysis, and dependency auditing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->