### PR TITLE
Port :erlang.pid_to_list/1 to JS

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -1510,6 +1510,20 @@ const Erlang = {
   // End not/1
   // Deps: []
 
+  // Start pid_to_list/1
+  "pid_to_list/1": (pid) => {
+    if (!Type.isPid(pid)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(1, "not a pid"),
+      );
+    }
+
+    const pidString = `<${pid.segments.join(".")}>`;
+    return Bitstring.toCodepoints(Type.bitstring(pidString));
+  },
+  // End pid_to_list/1
+  // Deps: []
+
   // Start orelse/2
   "orelse/2": (leftFun, rightFun, context) => {
     const left = leftFun(context);

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -3496,6 +3496,39 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "pid_to_list/1" do
+    test "single digit segments" do
+      p = :erlang.list_to_pid(~c"<0.1.0>")
+      assert :erlang.pid_to_list(p) == ~c"<0.1.0>"
+    end
+
+    test "multi-digit segments" do
+      p = :erlang.list_to_pid(~c"<0.11.222>")
+      assert :erlang.pid_to_list(p) == ~c"<0.11.222>"
+    end
+
+    test "self() pid" do
+      # Self returns a PID, so we can convert it to list and back
+      p = self()
+      list = :erlang.pid_to_list(p)
+      assert is_list(list)
+      # Verify the format matches the PID string format
+      assert Enum.all?(list, &is_integer/1)
+    end
+
+    test "not a pid" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not a pid"),
+                   {:erlang, :pid_to_list, [123]}
+    end
+
+    test "atom is not a pid" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not a pid"),
+                   {:erlang, :pid_to_list, [:test]}
+    end
+  end
+
   describe "rem/2" do
     test "returns remainder of positive integers" do
       assert :erlang.rem(10, 3) === 1

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -5603,6 +5603,57 @@ describe("Erlang", () => {
     });
   });
 
+  describe("pid_to_list/1", () => {
+    const fun = Erlang["pid_to_list/1"];
+
+    it("valid pid with single digit segments", () => {
+      const pid = Type.pid("client", [0, 1, 0], "client");
+      const result = fun(pid);
+
+      // "<0.1.0>" has codepoints [60, 48, 46, 49, 46, 48, 62]
+      const expected = Type.list([
+        Type.integer(60), // <
+        Type.integer(48), // 0
+        Type.integer(46), // .
+        Type.integer(49), // 1
+        Type.integer(46), // .
+        Type.integer(48), // 0
+        Type.integer(62), // >
+      ]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("valid pid with multi-digit segments", () => {
+      const pid = Type.pid("client", [0, 11, 222], "client");
+      const result = fun(pid);
+
+      // "<0.11.222>" has codepoints [60, 48, 46, 49, 49, 46, 50, 50, 50, 62]
+      const expected = Type.list([
+        Type.integer(60), // <
+        Type.integer(48), // 0
+        Type.integer(46), // .
+        Type.integer(49), // 1
+        Type.integer(49), // 1
+        Type.integer(46), // .
+        Type.integer(50), // 2
+        Type.integer(50), // 2
+        Type.integer(50), // 2
+        Type.integer(62), // >
+      ]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("raises ArgumentError if the argument is not a pid", () => {
+      assertBoxedError(
+        () => fun(Type.integer(123)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not a pid"),
+      );
+    });
+  });
+
   describe("rem/2", () => {
     const testedFun = Erlang["rem/2"];
 


### PR DESCRIPTION
Closes #593 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pid_to_list/1` function to convert PIDs to string representation and return codepoints with proper error handling.

* **Tests**
  * Added comprehensive test coverage including single and multi-digit segments, self() conversion, and error validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->