### PR TITLE
Port :rand.uniform/0 to JS

### DIFF
--- a/assets/js/erlang/rand.mjs
+++ b/assets/js/erlang/rand.mjs
@@ -9,6 +9,14 @@ import Type from "../type.mjs";
 
 const Erlang_Rand = {
   // TODO: Erlang docs say that "state in the process dictionary" is used
+  // Start uniform/0
+  "uniform/0": () => {
+    return Type.float(Math.random());
+  },
+  // End uniform/0
+  // Deps: []
+
+  // TODO: Erlang docs say that "state in the process dictionary" is used
   // Start uniform/1
   "uniform/1": (integer) => {
     if (

--- a/test/elixir/hologram/ex_js_consistency/erlang/rand_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/rand_test.exs
@@ -9,6 +9,16 @@ defmodule Hologram.ExJsConsistency.Erlang.RandTest do
 
   @moduletag :consistency
 
+  describe "uniform/0" do
+    test "returns a float in range [0.0, 1.0)" do
+      result = :rand.uniform()
+
+      assert is_float(result)
+      assert result >= 0.0
+      assert result < 1.0
+    end
+  end
+
   describe "uniform/1" do
     @expected_err_msg ~r'no function clause matching in :rand.uniform_s/2'
 

--- a/test/javascript/erlang/rand_test.mjs
+++ b/test/javascript/erlang/rand_test.mjs
@@ -16,6 +16,18 @@ defineGlobalErlangAndElixirModules();
 // Always update both together.
 
 describe("Erlang_Rand", () => {
+  describe("uniform/0", () => {
+    const uniform = Erlang_Rand["uniform/0"];
+
+    it("returns a float in range [0.0, 1.0)", () => {
+      const result = uniform();
+
+      assert.isTrue(Type.isFloat(result));
+      assert.isAtLeast(result.value, 0.0);
+      assert.isBelow(result.value, 1.0);
+    });
+  });
+
   describe("uniform/1", () => {
     const uniform = Erlang_Rand["uniform/1"];
 


### PR DESCRIPTION
Closes #565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating uniform random floats in the range [0.0, 1.0)

* **Tests**
  * Added comprehensive test coverage for the new random number generation capability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->