### PR TITLE
Port :os.system_time/0 and :os.system_time/1 to JS

### DIFF
--- a/assets/js/erlang/os.mjs
+++ b/assets/js/erlang/os.mjs
@@ -1,0 +1,110 @@
+"use strict";
+
+import Interpreter from "../interpreter.mjs";
+import Type from "../type.mjs";
+
+// IMPORTANT!
+// If the given ported Erlang function calls other Erlang functions, then list such dependencies in the "Deps" comment (see :erlang./=/2 for an example).
+// Also, in such case add respective call graph edges in Hologram.CallGraph.list_runtime_mfas/1.
+
+const Erlang_Os = {
+  // Start system_time/0
+  "system_time/0": () => {
+    // Returns current system time in native time unit (nanoseconds)
+    // In Erlang, system_time/0 returns a large integer representing nanoseconds since epoch
+    // TODO: Once PR #590 (monotonic_time) is merged, review time source patterns for consistency
+    const timeNs = BigInt(Date.now()) * BigInt(1000000);
+    return Type.integer(timeNs);
+  },
+  // End system_time/0
+  // Deps: []
+
+  // Start system_time/1
+  "system_time/1": (unit) => {
+    // Get current time source
+    // Prefer performance API for perf_counter, otherwise use Date.now()
+    // Similar to Erlang's system_time which returns a large integer
+    // TODO: Once PR #590 (monotonic_time) is merged, review time source patterns for consistency
+    let timeNs;
+
+    // Check if this is a perf_counter request and performance API is available
+    const isPerformanceRequest =
+      Type.isAtom(unit) &&
+      unit.value === "perf_counter" &&
+      typeof performance !== "undefined" &&
+      performance.timeOrigin &&
+      performance.now;
+
+    if (isPerformanceRequest) {
+      // For perf_counter, compute epoch-based timestamp using performance API
+      // performance.timeOrigin gives the epoch time (milliseconds), performance.now() gives
+      // high-resolution elapsed time since page load. Together they provide an accurate
+      // epoch-based high-resolution timestamp.
+      const epochTimeMs =
+        BigInt(Math.floor(performance.timeOrigin)) +
+        BigInt(Math.floor(performance.now()));
+      timeNs = epochTimeMs * BigInt(1000000);
+    } else {
+      // For all other units, use Date.now() as the time source
+      timeNs = BigInt(Date.now()) * BigInt(1000000);
+    }
+
+    // Convert unit parameter to a numeric value (parts per second)
+    // TODO: Once PR #603 (convert_time_unit/3) is merged, consider refactoring unit handling
+    //       to use the centralized convert_time_unit/3 function for consistency
+    let unitPps;
+
+    if (Type.isAtom(unit)) {
+      switch (unit.value) {
+        case "second":
+          unitPps = BigInt(1);
+          break;
+        case "millisecond":
+          unitPps = BigInt(1000);
+          break;
+        case "microsecond":
+          unitPps = BigInt(1000000);
+          break;
+        case "nanosecond":
+          unitPps = BigInt(1000000000);
+          break;
+        case "native":
+          unitPps = BigInt(1000000000); // Native unit is nanoseconds in both Erlang and here
+          break;
+        case "perf_counter":
+          unitPps = BigInt(1000000000); // perf_counter is nanoseconds
+          break;
+        default:
+          Interpreter.raiseArgumentError(
+            Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+          );
+      }
+    } else if (Type.isInteger(unit)) {
+      if (unit.value <= 0n) {
+        Interpreter.raiseArgumentError(
+          Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+        );
+      }
+
+      unitPps = BigInt(unit.value);
+    } else {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    }
+
+    // Convert from nanoseconds to the requested unit
+    // timeNs is in nanoseconds, which is 1000000000 pps
+    // To convert to target unit: (timeNs / 1000000000) * unitPps
+    // TODO: Once PR #603 (convert_time_unit/3) is merged, this conversion logic could be
+    //       replaced with: Erlang['convert_time_unit/3'](timeNs, Type.integer(1000000000n), unit)
+    const convertedTime = (timeNs * unitPps) / BigInt(1000000000);
+
+    return Type.integer(convertedTime);
+  },
+  // End system_time/1
+  // Deps: []
+  // Future deps: [:erlang.convert_time_unit/3] (after PR #603 merge)
+};
+
+export default Erlang_Os;

--- a/test/elixir/hologram/ex_js_consistency/erlang/os_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/os_test.exs
@@ -1,0 +1,182 @@
+defmodule Hologram.ExJsConsistency.Erlang.OsTest do
+  @moduledoc """
+  IMPORTANT!
+  Each Elixir consistency test has a related JavaScript test in test/javascript/erlang/os_test.mjs
+  Always update both together.
+  """
+
+  use Hologram.Test.BasicCase, async: true
+
+  import Hologram.Commons.TestUtils
+
+  @moduletag :consistency
+
+  describe "system_time/0" do
+    test "returns an integer" do
+      result = :os.system_time()
+      assert is_integer(result)
+    end
+
+    test "returns a positive integer" do
+      result = :os.system_time()
+      assert result > 0
+    end
+
+    test "returns nanoseconds since epoch" do
+      result = :os.system_time()
+      now = System.os_time(:nanosecond)
+      # Allow 100ms (100000000 nanoseconds) difference for test execution
+      assert abs(result - now) < 100_000_000
+    end
+  end
+
+  describe "system_time/1" do
+    test "returns an integer with millisecond atom unit" do
+      result = :os.system_time(:millisecond)
+      assert is_integer(result)
+      assert result > 0
+    end
+
+    test "returns milliseconds with millisecond atom unit" do
+      result = :os.system_time(:millisecond)
+      now = System.os_time(:millisecond)
+      # Allow 100ms difference
+      assert abs(result - now) < 100
+    end
+
+    test "returns an integer with second atom unit" do
+      result = :os.system_time(:second)
+      assert is_integer(result)
+      assert result > 0
+    end
+
+    test "returns seconds with second atom unit" do
+      result = :os.system_time(:second)
+      now = System.os_time(:second)
+      # Allow 1 second difference
+      assert abs(result - now) <= 1
+    end
+
+    test "returns an integer with microsecond atom unit" do
+      result = :os.system_time(:microsecond)
+      assert is_integer(result)
+      assert result > 0
+    end
+
+    test "returns microseconds with microsecond atom unit" do
+      result = :os.system_time(:microsecond)
+      now = System.os_time(:microsecond)
+      # Allow 100000 microseconds (100ms) difference
+      assert abs(result - now) < 100_000
+    end
+
+    test "returns an integer with nanosecond atom unit" do
+      result = :os.system_time(:nanosecond)
+      assert is_integer(result)
+      assert result > 0
+    end
+
+    test "returns nanoseconds with nanosecond atom unit" do
+      result = :os.system_time(:nanosecond)
+      now = System.os_time(:nanosecond)
+      # Allow 100ms (100000000 nanoseconds) difference
+      assert abs(result - now) < 100_000_000
+    end
+
+    test "returns an integer with native atom unit" do
+      result = :os.system_time(:native)
+      assert is_integer(result)
+      assert result > 0
+    end
+
+    test "returns nanoseconds with native atom unit" do
+      result = :os.system_time(:native)
+      now = System.os_time(:nanosecond)
+      # Allow 100ms (100000000 nanoseconds) difference
+      assert abs(result - now) < 100_000_000
+    end
+
+    test "returns an integer with perf_counter atom unit" do
+      result = :os.system_time(:perf_counter)
+      assert is_integer(result)
+      assert result > 0
+    end
+
+    test "returns epoch-based nanoseconds with perf_counter atom unit" do
+      result = :os.system_time(:perf_counter)
+      now = System.os_time(:nanosecond)
+      # Allow 100ms (100000000 nanoseconds) difference for test execution
+      # perf_counter should be epoch-based like other units
+      assert abs(result - now) < 100_000_000
+    end
+
+    test "returns an integer with numeric unit" do
+      result = :os.system_time(1000)
+      assert is_integer(result)
+      assert result > 0
+    end
+
+    test "returns milliseconds with numeric unit 1000 (parts per second)" do
+      result = :os.system_time(1000)
+      now = System.os_time(:millisecond)
+      # Allow 100ms difference
+      assert abs(result - now) < 100
+    end
+
+    test "returns seconds with numeric unit 1" do
+      result = :os.system_time(1)
+      now = System.os_time(:second)
+      # Allow 1 second difference
+      assert abs(result - now) <= 1
+    end
+
+    test "returns nanoseconds with numeric unit 1000000000" do
+      result = :os.system_time(1_000_000_000)
+      now = System.os_time(:nanosecond)
+      # Allow 100ms (100000000 nanoseconds) difference
+      assert abs(result - now) < 100_000_000
+    end
+
+    test "raises ArgumentError if unit is not an atom or integer" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:os, :system_time, [[]]}
+    end
+
+    test "raises ArgumentError if unit atom is invalid" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:os, :system_time, [:invalid_unit]}
+    end
+
+    test "raises ArgumentError if unit is a float" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:os, :system_time, [1.5]}
+    end
+
+    test "raises ArgumentError if unit is a bitstring" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:os, :system_time, ["test"]}
+    end
+
+    test "raises ArgumentError if unit is a tuple" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:os, :system_time, [{:test}]}
+    end
+
+    test "raises ArgumentError if unit is zero integer" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:os, :system_time, [0]}
+    end
+
+    test "raises ArgumentError if unit is negative integer" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:os, :system_time, [-1]}
+    end
+  end
+end

--- a/test/javascript/erlang/os_test.mjs
+++ b/test/javascript/erlang/os_test.mjs
@@ -1,0 +1,202 @@
+"use strict";
+
+import {
+  assert,
+  assertBoxedError,
+  defineGlobalErlangAndElixirModules,
+} from "../support/helpers.mjs";
+
+import Erlang_Os from "../../../assets/js/erlang/os.mjs";
+import Interpreter from "../../../assets/js/interpreter.mjs";
+import Type from "../../../assets/js/type.mjs";
+
+defineGlobalErlangAndElixirModules();
+
+describe("Os", () => {
+  describe("system_time/0", () => {
+    const systemTime = Erlang_Os["system_time/0"];
+
+    it("returns an integer", () => {
+      const result = systemTime();
+      assert(Type.isInteger(result));
+    });
+
+    it("returns a positive integer", () => {
+      const result = systemTime();
+      assert(result.value > 0n);
+    });
+
+    it("returns nanoseconds since epoch", () => {
+      const result = systemTime();
+      const now = BigInt(Date.now()) * BigInt(1000000);
+      // Allow 100ms (100000000 nanoseconds) difference for test execution
+      assert(Math.abs(Number(result.value - now)) < 100000000);
+    });
+  });
+
+  describe("system_time/1", () => {
+    const systemTime = Erlang_Os["system_time/1"];
+
+    it("returns an integer with millisecond atom unit", () => {
+      const result = systemTime(Type.atom("millisecond"));
+      assert(Type.isInteger(result));
+      assert(result.value > 0n);
+    });
+
+    it("returns milliseconds with millisecond atom unit", () => {
+      const result = systemTime(Type.atom("millisecond"));
+      const now = BigInt(Date.now());
+      // Allow 100ms difference
+      assert(Math.abs(Number(result.value - now)) < 100);
+    });
+
+    it("returns an integer with second atom unit", () => {
+      const result = systemTime(Type.atom("second"));
+      assert(Type.isInteger(result));
+      assert(result.value > 0n);
+    });
+
+    it("returns seconds with second atom unit", () => {
+      const result = systemTime(Type.atom("second"));
+      const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+      // Allow 1 second difference
+      assert(Math.abs(Number(result.value - nowSeconds)) <= 1);
+    });
+
+    it("returns an integer with microsecond atom unit", () => {
+      const result = systemTime(Type.atom("microsecond"));
+      assert(Type.isInteger(result));
+      assert(result.value > 0n);
+    });
+
+    it("returns microseconds with microsecond atom unit", () => {
+      const result = systemTime(Type.atom("microsecond"));
+      const nowMicroseconds = BigInt(Date.now()) * BigInt(1000);
+      // Allow 100000 microseconds (100ms) difference
+      assert(Math.abs(Number(result.value - nowMicroseconds)) < 100000);
+    });
+
+    it("returns an integer with nanosecond atom unit", () => {
+      const result = systemTime(Type.atom("nanosecond"));
+      assert(Type.isInteger(result));
+      assert(result.value > 0n);
+    });
+
+    it("returns nanoseconds with nanosecond atom unit", () => {
+      const result = systemTime(Type.atom("nanosecond"));
+      const nowNanoseconds = BigInt(Date.now()) * BigInt(1000000);
+      // Allow 100000000 nanoseconds (100ms) difference
+      assert(Math.abs(Number(result.value - nowNanoseconds)) < 100000000);
+    });
+
+    it("returns an integer with native atom unit", () => {
+      const result = systemTime(Type.atom("native"));
+      assert(Type.isInteger(result));
+      assert(result.value > 0n);
+    });
+
+    it("returns nanoseconds with native atom unit", () => {
+      const result = systemTime(Type.atom("native"));
+      const now = BigInt(Date.now()) * BigInt(1000000);
+      // Allow 100ms (100000000 nanoseconds) difference
+      assert(Math.abs(Number(result.value - now)) < 100000000);
+    });
+
+    it("returns an integer with perf_counter atom unit", () => {
+      const result = systemTime(Type.atom("perf_counter"));
+      assert(Type.isInteger(result));
+      assert(result.value > 0n);
+    });
+
+    it("returns epoch-based nanoseconds with perf_counter atom unit", () => {
+      const result = systemTime(Type.atom("perf_counter"));
+      const now = BigInt(Date.now()) * BigInt(1000000);
+      // Allow 100ms (100000000 nanoseconds) difference for test execution
+      // perf_counter should be epoch-based like other units
+      assert(Math.abs(Number(result.value - now)) < 100000000);
+    });
+
+    it("returns an integer with numeric unit", () => {
+      const result = systemTime(Type.integer(1000n));
+      assert(Type.isInteger(result));
+      assert(result.value > 0n);
+    });
+
+    it("returns milliseconds with numeric unit 1000 (parts per second)", () => {
+      const result = systemTime(Type.integer(1000n));
+      const now = BigInt(Date.now());
+      // Allow 100ms difference
+      assert(Math.abs(Number(result.value - now)) < 100);
+    });
+
+    it("returns seconds with numeric unit 1", () => {
+      const result = systemTime(Type.integer(1n));
+      const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+      // Allow 1 second difference
+      assert(Math.abs(Number(result.value - nowSeconds)) <= 1);
+    });
+
+    it("returns nanoseconds with numeric unit 1000000000", () => {
+      const result = systemTime(Type.integer(1000000000n));
+      const nowNanoseconds = BigInt(Date.now()) * BigInt(1000000);
+      // Allow 100ms (100000000 nanoseconds) difference
+      assert(Math.abs(Number(result.value - nowNanoseconds)) < 100000000);
+    });
+
+    it("raises ArgumentError if unit is not an atom or integer", () => {
+      assertBoxedError(
+        () => systemTime(Type.list([])),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError if unit atom is invalid", () => {
+      assertBoxedError(
+        () => systemTime(Type.atom("invalid_unit")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError if unit is a float", () => {
+      assertBoxedError(
+        () => systemTime(Type.float(1.5)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError if unit is a bitstring", () => {
+      assertBoxedError(
+        () => systemTime(Type.bitstring("test")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError if unit is a tuple", () => {
+      assertBoxedError(
+        () => systemTime(Type.tuple([Type.atom("test")])),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError if unit is zero integer", () => {
+      assertBoxedError(
+        () => systemTime(Type.integer(0n)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError if unit is negative integer", () => {
+      assertBoxedError(
+        () => systemTime(Type.integer(-1n)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #609 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OS time utilities exposing system_time/0 and system_time/1 with support for seconds, milliseconds, microseconds, nanoseconds, native unit, and performance-counter readings.

* **Tests**
  * Added comprehensive JavaScript and Elixir tests validating timing accuracy across units, type/positivity checks, numeric-unit behavior, and robust error handling for invalid inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->