### PR TITLE
Port :binary.part/2 and :binary.part/3 to JS

### DIFF
--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -22,6 +22,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:binary, :_boyer_moore_search, 3}, {:binary, :_parse_search_opts, 1}},
     {{:binary, :_parse_search_opts, 1}, {:lists, :keyfind, 3}},
     {{:binary, :compile_pattern, 1}, {:erlang, :make_ref, 0}},
+    {{:binary, :part, 2}, {:binary, :part, 3}},
     {{:elixir_locals, :yank, 2}, {:maps, :remove, 2}},
     {{:erlang, :"=<", 2}, {:erlang, :<, 2}},
     {{:erlang, :"=<", 2}, {:erlang, :==, 2}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/binary_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/binary_test.exs
@@ -271,4 +271,174 @@ defmodule Hologram.ExJsConsistency.Erlang.BinaryTest do
                    {:binary, :last, [""]}
     end
   end
+
+  describe "part/2" do
+    test "returns part of binary with tuple {start, length}" do
+      result = :binary.part("hello world", {0, 5})
+      assert result == "hello"
+    end
+
+    test "returns middle part with tuple" do
+      result = :binary.part("hello world", {6, 5})
+      assert result == "world"
+    end
+
+    test "returns empty binary when length is 0" do
+      result = :binary.part("hello", {0, 0})
+      assert result == ""
+    end
+
+    test "returns last character" do
+      result = :binary.part("hello", {4, 1})
+      assert result == "o"
+    end
+
+    test "handles bytes-based binary" do
+      result = :binary.part(<<72, 101, 108, 108, 111>>, {1, 3})
+      assert result == "ell"
+    end
+
+    test "handles invalid UTF-8 bytes" do
+      result = :binary.part(<<0xC3, 0x28, 0x41>>, {0, 3})
+      assert result == <<0xC3, 0x28, 0x41>>
+    end
+
+    test "raises ArgumentError when subject is not a binary" do
+      assert_raise ArgumentError, fn ->
+        :binary.part(:notabinary, {0, 1})
+      end
+    end
+
+    test "raises ArgumentError when subject is a non-binary bitstring" do
+      assert_raise ArgumentError, fn ->
+        :binary.part(<<1::1, 0::1, 1::1>>, {0, 1})
+      end
+    end
+
+    test "raises ArgumentError when posLen is not a tuple" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", [0, 1])
+      end
+    end
+
+    test "raises ArgumentError when tuple has wrong length" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", {0})
+      end
+    end
+
+    test "raises ArgumentError when start is not an integer" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", {:invalid, 1})
+      end
+    end
+
+    test "raises ArgumentError when length is not an integer" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", {0, :invalid})
+      end
+    end
+
+    test "raises ArgumentError when start is negative" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", {-1, 2})
+      end
+    end
+
+    test "extracts backwards with negative length" do
+      result = :binary.part("hello", {5, -3})
+      assert result == "llo"
+    end
+
+    test "raises ArgumentError when part extends past end" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", {2, 10})
+      end
+    end
+
+    test "raises ArgumentError when negative length goes before start" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", {2, -3})
+      end
+    end
+  end
+
+  describe "part/3" do
+    test "returns part of binary starting at position with given length" do
+      result = :binary.part("hello world", 0, 5)
+      assert result == "hello"
+    end
+
+    test "returns middle part of binary" do
+      result = :binary.part("hello world", 6, 5)
+      assert result == "world"
+    end
+
+    test "returns empty binary when length is 0" do
+      result = :binary.part("hello", 0, 0)
+      assert result == ""
+    end
+
+    test "returns last character" do
+      result = :binary.part("hello", 4, 1)
+      assert result == "o"
+    end
+
+    test "handles bytes-based binary" do
+      result = :binary.part(<<72, 101, 108, 108, 111>>, 1, 3)
+      assert result == "ell"
+    end
+
+    test "handles invalid UTF-8 bytes" do
+      result = :binary.part(<<0xC3, 0x28, 0x41>>, 0, 3)
+      assert result == <<0xC3, 0x28, 0x41>>
+    end
+
+    test "raises ArgumentError when subject is not a binary" do
+      assert_raise ArgumentError, fn ->
+        :binary.part(:notabinary, 0, 1)
+      end
+    end
+
+    test "raises ArgumentError when subject is a non-binary bitstring" do
+      assert_raise ArgumentError, fn ->
+        :binary.part(<<1::1, 0::1, 1::1>>, 0, 1)
+      end
+    end
+
+    test "raises ArgumentError when start is not an integer" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", :invalid, 1)
+      end
+    end
+
+    test "raises ArgumentError when length is not an integer" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", 0, :invalid)
+      end
+    end
+
+    test "raises ArgumentError when start is negative" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", -1, 2)
+      end
+    end
+
+    test "extracts backwards with negative length" do
+      result = :binary.part("hello", 5, -3)
+      assert result == "llo"
+    end
+
+    test "raises ArgumentError when part extends past end" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", 2, 10)
+      end
+    end
+
+    test "raises ArgumentError when negative length goes before start" do
+      assert_raise ArgumentError, fn ->
+        :binary.part("hello", 2, -3)
+      end
+    end
+  end
 end

--- a/test/javascript/erlang/binary_test.mjs
+++ b/test/javascript/erlang/binary_test.mjs
@@ -664,4 +664,290 @@ describe("Erlang_Binary", () => {
   //     });
   //   });
   // });
+
+  describe("part/2", () => {
+    const part2 = Erlang_Binary["part/2"];
+
+    it("returns part of binary with tuple {start, length}", () => {
+      const result = part2(
+        Type.bitstring("hello world"),
+        Type.tuple([Type.integer(0), Type.integer(5)]),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("hello"));
+    });
+
+    it("returns middle part with tuple", () => {
+      const result = part2(
+        Type.bitstring("hello world"),
+        Type.tuple([Type.integer(6), Type.integer(5)]),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("world"));
+    });
+
+    it("returns empty binary when length is 0", () => {
+      const result = part2(
+        Type.bitstring("hello"),
+        Type.tuple([Type.integer(0), Type.integer(0)]),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText(""));
+    });
+
+    it("returns last character", () => {
+      const result = part2(
+        Type.bitstring("hello"),
+        Type.tuple([Type.integer(4), Type.integer(1)]),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("o"));
+    });
+
+    it("handles bytes-based binary", () => {
+      const binary = Bitstring.fromBytes([72, 101, 108, 108, 111]);
+      const result = part2(
+        binary,
+        Type.tuple([Type.integer(1), Type.integer(3)]),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("ell"));
+    });
+
+    it("handles invalid UTF-8 bytes", () => {
+      const binary = Bitstring.fromBytes([0xc3, 0x28, 0x41]);
+      const result = part2(
+        binary,
+        Type.tuple([Type.integer(0), Type.integer(3)]),
+      );
+      assertBoxedStrictEqual(result, binary);
+    });
+
+    it("raises ArgumentError when subject is not a binary", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.atom("notabinary"),
+            Type.tuple([Type.integer(0), Type.integer(1)]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when subject is a non-binary bitstring", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.bitstring([1, 0, 1]),
+            Type.tuple([Type.integer(0), Type.integer(1)]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when posLen is not a tuple", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.bitstring("hello"),
+            Type.list([Type.integer(0), Type.integer(1)]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when tuple has wrong length", () => {
+      assertBoxedError(
+        () => part2(Type.bitstring("hello"), Type.tuple([Type.integer(0)])),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when start is not an integer", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.bitstring("hello"),
+            Type.tuple([Type.atom("invalid"), Type.integer(1)]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when length is not an integer", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.bitstring("hello"),
+            Type.tuple([Type.integer(0), Type.atom("invalid")]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when start is negative", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.bitstring("hello"),
+            Type.tuple([Type.integer(-1), Type.integer(2)]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("extracts backwards with negative length", () => {
+      const result = part2(
+        Type.bitstring("hello"),
+        Type.tuple([Type.integer(5), Type.integer(-3)]),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("llo"));
+    });
+
+    it("raises ArgumentError when part extends past end", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.bitstring("hello"),
+            Type.tuple([Type.integer(2), Type.integer(10)]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when negative length goes before start", () => {
+      assertBoxedError(
+        () =>
+          part2(
+            Type.bitstring("hello"),
+            Type.tuple([Type.integer(2), Type.integer(-3)]),
+          ),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+  });
+
+  describe("part/3", () => {
+    const part3 = Erlang_Binary["part/3"];
+
+    it("returns part of binary starting at position with given length", () => {
+      const result = part3(
+        Type.bitstring("hello world"),
+        Type.integer(0),
+        Type.integer(5),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("hello"));
+    });
+
+    it("returns middle part of binary", () => {
+      const result = part3(
+        Type.bitstring("hello world"),
+        Type.integer(6),
+        Type.integer(5),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("world"));
+    });
+
+    it("returns empty binary when length is 0", () => {
+      const result = part3(
+        Type.bitstring("hello"),
+        Type.integer(0),
+        Type.integer(0),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText(""));
+    });
+
+    it("returns last character", () => {
+      const result = part3(
+        Type.bitstring("hello"),
+        Type.integer(4),
+        Type.integer(1),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("o"));
+    });
+
+    it("handles bytes-based binary", () => {
+      const binary = Bitstring.fromBytes([72, 101, 108, 108, 111]);
+      const result = part3(binary, Type.integer(1), Type.integer(3));
+      assertBoxedStrictEqual(result, Bitstring.fromText("ell"));
+    });
+
+    it("handles invalid UTF-8 bytes", () => {
+      const binary = Bitstring.fromBytes([0xc3, 0x28, 0x41]);
+      const result = part3(binary, Type.integer(0), Type.integer(3));
+      assertBoxedStrictEqual(result, binary);
+    });
+
+    it("raises ArgumentError when subject is not a binary", () => {
+      assertBoxedError(
+        () => part3(Type.atom("notabinary"), Type.integer(0), Type.integer(1)),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when subject is a non-binary bitstring", () => {
+      assertBoxedError(
+        () =>
+          part3(Type.bitstring([1, 0, 1]), Type.integer(0), Type.integer(1)),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when start is not an integer", () => {
+      assertBoxedError(
+        () =>
+          part3(Type.bitstring("hello"), Type.atom("invalid"), Type.integer(1)),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when length is not an integer", () => {
+      assertBoxedError(
+        () =>
+          part3(Type.bitstring("hello"), Type.integer(0), Type.atom("invalid")),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when start is negative", () => {
+      assertBoxedError(
+        () => part3(Type.bitstring("hello"), Type.integer(-1), Type.integer(2)),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("extracts backwards with negative length", () => {
+      const result = part3(
+        Type.bitstring("hello"),
+        Type.integer(5),
+        Type.integer(-3),
+      );
+      assertBoxedStrictEqual(result, Bitstring.fromText("llo"));
+    });
+
+    it("raises ArgumentError when part extends past end", () => {
+      assertBoxedError(
+        () => part3(Type.bitstring("hello"), Type.integer(2), Type.integer(10)),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+
+    it("raises ArgumentError when negative length goes before start", () => {
+      assertBoxedError(
+        () => part3(Type.bitstring("hello"), Type.integer(2), Type.integer(-3)),
+        "ArgumentError",
+        "argument error",
+      );
+    });
+  });
 });


### PR DESCRIPTION
Closes #613 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added binary "part" slicing (start/length and tuple variants) including reverse (negative-length) slicing, improved bounds handling, and correct text/bytes synchronization.

* **Tests**
  * Comprehensive test coverage added across Elixir and JavaScript suites for part operations: normal and boundary cases, bytes vs UTF-8 behavior, negative-length/backwards slicing, and extensive error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->