### PR TITLE
Port :binary.split/2 and :binary.split/3 to JS

### DIFF
--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -18,10 +18,12 @@ defmodule Hologram.Compiler.CallGraph do
 
   # TODO: Determine automatically based on deps annotations next to function implementations
   @erlang_mfa_edges [
-    {{:binary, :_aho_corasick_search, 3}, {:binary, :_parse_search_opts, 1}},
-    {{:binary, :_boyer_moore_search, 3}, {:binary, :_parse_search_opts, 1}},
-    {{:binary, :_parse_search_opts, 1}, {:lists, :keyfind, 3}},
     {{:binary, :compile_pattern, 1}, {:erlang, :make_ref, 0}},
+    {{:binary, :split, 2}, {:binary, :split, 3}},
+    {{:binary, :split, 3}, {:binary, :_parse_search_opts, 1}},
+    {{:binary, :split, 3}, {:binary, :_aho_corasick_search, 3}},
+    {{:binary, :split, 3}, {:binary, :_boyer_moore_search, 4}},
+    {{:binary, :split, 3}, {:binary, :compile_pattern, 1}},
     {{:elixir_locals, :yank, 2}, {:maps, :remove, 2}},
     {{:erlang, :"=<", 2}, {:erlang, :<, 2}},
     {{:erlang, :"=<", 2}, {:erlang, :==, 2}},


### PR DESCRIPTION
Closes #355 

Implements module level helpers `_aho_corasick_search/3`, `_boyer_moore_search/4` and `_parse_search_opts/1` as these will also be required for future `:binary` module implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pattern-based binary splitting with options: global vs first-match, trim/trim_all, and scope ranges; returns UTF-8 text when valid, otherwise raw bytes.
  * Support for compiled/optimized pattern search for faster single- and multi-pattern matching.

* **Tests**
  * Extensive coverage for split/search behavior: multi-byte & multiple patterns, consecutive matches, scope/trimming interactions, UTF-8 vs raw bytes, compiled-pattern usage, and thorough argument validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->