### PR TITLE
Port :elixir_aliases.safe_concat/1 to JS

### DIFF
--- a/assets/js/erlang/elixir_aliases.mjs
+++ b/assets/js/erlang/elixir_aliases.mjs
@@ -3,7 +3,6 @@
 import Bitstring from "../bitstring.mjs";
 import Interpreter from "../interpreter.mjs";
 import Type from "../type.mjs";
-import Erlang from "./erlang.mjs";
 
 // IMPORTANT!
 // If the given ported Erlang function calls other Erlang functions, then list such dependencies in the "Deps" comment (see :erlang./=/2 for an example).
@@ -65,19 +64,16 @@ const Erlang_Elixir_Aliases = {
   },
   // End concat/1
   // Deps: []
-  // Note: due to dependency on :erlang.binary_to_existing_atom/1 the behaviour of the client version is inconsistent
-  // with the server version.
-  // The client version works exactly the same as concat/1.
+  // Note: there's no atom table limitation in the client-side JavaScript runtime,
+  // safe_concat/1 can simply delegate directly to concat/1.
   // Start safe_concat/1
   "safe_concat/1": function (segments) {
-    const concat_atom = Erlang_Elixir_Aliases["concat/1"](segments);
-    const concat_result = Erlang["atom_to_binary/1"](concat_atom);
-    const result = Erlang["binary_to_existing_atom/1"](concat_result);
+    const result = Erlang_Elixir_Aliases["concat/1"](segments);
 
     return result;
   },
   // End safe_concat/1
-  // Deps: [:elixir_aliases.concat/1, :erlang.atom_to_binary/1, :erlang.binary_to_existing_atom/1]
+  // Deps: [:elixir_aliases.concat/1]
 };
 
 export default Erlang_Elixir_Aliases;

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -25,8 +25,6 @@ defmodule Hologram.Compiler.CallGraph do
     {{:binary, :split, 3}, {:binary, :_parse_search_opts, 2}},
     {{:binary, :split, 3}, {:binary, :compile_pattern, 1}},
     {{:elixir_aliases, :safe_concat, 1}, {:elixir_aliases, :concat, 1}},
-    {{:elixir_aliases, :safe_concat, 1}, {:erlang, :atom_to_binary, 1}},
-    {{:elixir_aliases, :safe_concat, 1}, {:erlang, :binary_to_existing_atom, 1}},
     {{:elixir_locals, :yank, 2}, {:maps, :remove, 2}},
     {{:erlang, :"=<", 2}, {:erlang, :<, 2}},
     {{:erlang, :"=<", 2}, {:erlang, :==, 2}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/elixir_aliases_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/elixir_aliases_test.exs
@@ -83,8 +83,7 @@ defmodule Hologram.ExJsConsistency.Erlang.ElixirAliasesTest do
     end
   end
 
-  # Note: due to dependency on :erlang.binary_to_existing_atom/1 the behaviour of the client version is inconsistent
-  # with the server version.
-  # The client version works exactly the same as concat/1.
+  # Note: there's no atom table limitation in the client-side JavaScript runtime,
+  # safe_concat/1 can simply delegate directly to concat/1.
   # test "safe_concat/1"
 end

--- a/test/javascript/erlang/elixir_aliases_test.mjs
+++ b/test/javascript/erlang/elixir_aliases_test.mjs
@@ -183,18 +183,6 @@ describe("Erlang_Elixir_Aliases", () => {
     const safe_concat = Erlang_Elixir_Aliases["safe_concat/1"];
     const concat = Erlang_Elixir_Aliases["concat/1"];
 
-    it("works when the concatenated alias exists", () => {
-      const segments = Type.list([
-        Type.bitstring("Elixir"),
-        Type.bitstring("Enum"),
-      ]);
-
-      const result = safe_concat(segments);
-      const expectedAlias = Type.alias("Enum");
-
-      assert.deepStrictEqual(result, expectedAlias);
-    });
-
     it("delegates to concat/1", () => {
       const segments = Type.list([
         Type.bitstring("Aaa"),


### PR DESCRIPTION
Closes #621 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new safe concatenation API that delegates to the existing concat behavior.

* **Tests**
  * Added JavaScript tests verifying delegation; added an Elixir test placeholder and comments for parity checks.

* **Documentation**
  * Clarified client-side behavior: no atom-table limitation and delegation is straightforward, noted in test comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->