### PR TITLE
Fix tests for negative scope handling in :binary.split/3 JS port

### DIFF
--- a/test/elixir/hologram/ex_js_consistency/erlang/binary_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/binary_test.exs
@@ -655,6 +655,13 @@ defmodule Hologram.ExJsConsistency.Erlang.BinaryTest do
       assert :binary.split("abcdef", "d", [{:scope, {1, 3}}, :global]) == ["abc", "ef"]
     end
 
+    test "accepts negative scope length (reverse part)" do
+      subject = "hello world"
+      opts = [scope: {byte_size(subject), -6}]
+
+      assert :binary.split(subject, " ", opts) == ["hello", "world"]
+    end
+
     # Overlapping patterns
 
     test "with overlapping patterns, matches first found" do
@@ -745,12 +752,6 @@ defmodule Hologram.ExJsConsistency.Erlang.BinaryTest do
       assert_error ArgumentError,
                    build_argument_error_msg(3, "invalid options"),
                    fn -> :binary.split("abc", "b", scope: {1, 3}) end
-    end
-
-    test "raises ArgumentError for negative scope length" do
-      assert_error ArgumentError,
-                   build_argument_error_msg(3, "invalid options"),
-                   fn -> :binary.split("abc", "b", scope: {0, -1}) end
     end
   end
 end

--- a/test/javascript/erlang/binary_test.mjs
+++ b/test/javascript/erlang/binary_test.mjs
@@ -1451,6 +1451,25 @@ describe("Erlang_Binary", () => {
           Type.list([Bitstring.fromText("abc"), Bitstring.fromText("ef")]),
         );
       });
+
+      it("accepts negative scope length (reverse part)", () => {
+        const subject = Bitstring.fromText("hello world");
+        const pattern = Bitstring.fromText(" ");
+
+        const scope = Type.tuple([
+          Type.atom("scope"),
+          Type.tuple([Type.integer(11), Type.integer(-6)]),
+        ]);
+
+        const options = Type.list([scope]);
+
+        const result = split(subject, pattern, options);
+
+        assert.deepStrictEqual(
+          result,
+          Type.list([Bitstring.fromText("hello"), Bitstring.fromText("world")]),
+        );
+      });
     });
 
     describe("overlapping patterns", () => {
@@ -1670,24 +1689,6 @@ describe("Erlang_Binary", () => {
         const scope = Type.tuple([
           Type.atom("scope"),
           Type.tuple([Type.integer(1), Type.integer(3)]),
-        ]);
-
-        const options = Type.list([scope]);
-
-        assertBoxedError(
-          () => split(subject, pattern, options),
-          "ArgumentError",
-          Interpreter.buildArgumentErrorMsg(3, "invalid options"),
-        );
-      });
-
-      it("raises ArgumentError for negative scope length", () => {
-        const subject = Bitstring.fromText("abc");
-        const pattern = Bitstring.fromText("b");
-
-        const scope = Type.tuple([
-          Type.atom("scope"),
-          Type.tuple([Type.integer(0), Type.integer(-1)]),
         ]);
 
         const options = Type.list([scope]);


### PR DESCRIPTION
Fixes #626 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * split/3 function now accepts negative scope length to move the end boundary backwards, producing expected split results.

* **Tests**
  * Updated test cases to validate negative scope length handling in split/3 across Elixir and JavaScript implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->