### PR TITLE
Port :erlang.monotonic_time/0 and :erlang.monotonic_time/1 to JS

### DIFF
--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -50,6 +50,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:erlang, :iolist_to_binary, 1}, {:lists, :flatten, 1}},
     {{:erlang, :is_map_key, 2}, {:maps, :is_key, 2}},
     {{:erlang, :list_to_integer, 1}, {:erlang, :list_to_integer, 2}},
+    {{:erlang, :monotonic_time, 0}, {:erlang, :monotonic_time, 1}},
     {{:erlang, :split_binary, 2}, {:erlang, :byte_size, 1}},
     {{:erlang, :time_offset, 0}, {:erlang, :time_offset, 1}},
     {{:filename, :_do_flatten, 2}, {:erlang, :atom_to_list, 1}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -3852,6 +3852,65 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "monotonic_time/0" do
+    test "returns an integer" do
+      assert is_integer(:erlang.monotonic_time())
+    end
+
+    test "is monotonic non-decreasing" do
+      t1 = :erlang.monotonic_time()
+      t2 = :erlang.monotonic_time()
+      assert t2 >= t1
+    end
+  end
+
+  describe "monotonic_time/1" do
+    @units [:native, :second, :millisecond, :microsecond, :nanosecond]
+
+    test "all allowed units return integer" do
+      for u <- @units, do: assert(is_integer(:erlang.monotonic_time(u)))
+    end
+
+    test "nanosecond unit yields larger values than microsecond" do
+      # Get multiple samples to verify the mathematical relationship
+      micro1 = :erlang.monotonic_time(:microsecond)
+      nano1 = :erlang.monotonic_time(:nanosecond)
+      # Since 1 microsecond = 1000 nanoseconds, nano should be approximately 1000x micro
+      # We check that the ratio is close to 1000 (allowing for timing between calls)
+      # +1 to avoid division by very small numbers
+      ratio = div(nano1, micro1 + 1)
+      assert ratio >= 500 and ratio <= 2000
+    end
+
+    test "with positive integer unit" do
+      assert is_integer(:erlang.monotonic_time(1000))
+    end
+
+    test "raises ArgumentError when unit is less than 1" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:erlang, :monotonic_time, [0]}
+    end
+
+    test "raises ArgumentError when unit is negative" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:erlang, :monotonic_time, [-1]}
+    end
+
+    test "raises ArgumentError when unit is not a valid time unit atom" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:erlang, :monotonic_time, [:invalid]}
+    end
+
+    test "raises ArgumentError when unit is not atom or integer" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "invalid time unit"),
+                   {:erlang, :monotonic_time, [1.0]}
+    end
+  end
+
   describe "trunc/1" do
     test "drops fractional part of positive float" do
       assert :erlang.trunc(1.23) == 1

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -6179,6 +6179,87 @@ describe("Erlang", () => {
     });
   });
 
+  describe("monotonic_time/0", () => {
+    const monotonic_time = Erlang["monotonic_time/0"];
+
+    it("returns an integer", () => {
+      const result = monotonic_time();
+      assert.isTrue(Type.isInteger(result));
+    });
+
+    it("is monotonic non-decreasing", () => {
+      const t1 = monotonic_time().value;
+      const t2 = monotonic_time().value;
+
+      assert.isTrue(t2 >= t1);
+    });
+  });
+
+  describe("monotonic_time/1", () => {
+    const monotonic_time = Erlang["monotonic_time/1"];
+
+    it("all allowed units return integer", () => {
+      const units = [
+        "native",
+        "second",
+        "millisecond",
+        "microsecond",
+        "nanosecond",
+      ];
+
+      for (const u of units) {
+        assert.isTrue(Type.isInteger(monotonic_time(Type.atom(u))));
+      }
+    });
+
+    it("nanosecond unit yields larger values than microsecond", () => {
+      const micro = monotonic_time(Type.atom("microsecond"));
+      const nano = monotonic_time(Type.atom("nanosecond"));
+
+      // Since 1 microsecond = 1000 nanoseconds, nano should be approximately 1000x micro
+      // We check that the ratio is close to 1000 (allowing for timing between calls)
+      const ratio = nano.value / (micro.value + 1n); // +1 to avoid division by very small numbers
+      assert.isTrue(ratio >= 500n && ratio <= 2000n);
+    });
+
+    it("with positive integer unit", () => {
+      const result = monotonic_time(Type.integer(1000n));
+      assert.isTrue(Type.isInteger(result));
+    });
+
+    it("raises ArgumentError when unit is less than 1", () => {
+      assertBoxedError(
+        () => monotonic_time(Type.integer(0n)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError when unit is negative", () => {
+      assertBoxedError(
+        () => monotonic_time(Type.integer(-1n)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError when unit is not a valid time unit atom", () => {
+      assertBoxedError(
+        () => monotonic_time(Type.atom("invalid")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+
+    it("raises ArgumentError when unit is not atom or integer", () => {
+      assertBoxedError(
+        () => monotonic_time(Type.float(1.0)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "invalid time unit"),
+      );
+    });
+  });
+
   // describe("time_offset/0", () => {
   //   const time_offset = Erlang["time_offset/0"];
 


### PR DESCRIPTION
Closes #589 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monotonic_time/0 and monotonic_time/1 functions supporting multiple time units (native, second, millisecond, microsecond, nanosecond) with integer return values and error handling for invalid inputs.

* **Tests**
  * Added comprehensive test coverage for new monotonic_time functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->