### PR TITLE
Fix case where match placeholder is on right

### DIFF
--- a/assets/js/interpreter.mjs
+++ b/assets/js/interpreter.mjs
@@ -660,6 +660,10 @@ export default class Interpreter {
       return right;
     }
 
+    if (Type.isMatchPlaceholder(right)) {
+      return left;
+    }
+
     if (Type.isVariablePattern(left)) {
       return Interpreter.#matchVariablePattern(
         right,

--- a/test/javascript/interpreter_test.mjs
+++ b/test/javascript/interpreter_test.mjs
@@ -4934,6 +4934,18 @@ describe("Interpreter", () => {
         assert.deepStrictEqual(context.vars, varsWithEmptyMatchedValues);
       });
 
+      // :top = _placeholder
+      it("atom with right placeholder", () => {
+        const result = Interpreter.matchOperator(
+          Type.matchPlaceholder(),
+          Type.atom("top"),
+          context,
+        );
+
+        assert.deepStrictEqual(result, Type.atom("top"));
+        assert.deepStrictEqual(context.vars, varsWithEmptyMatchedValues);
+      });
+
       // <<prefix::size(8), _rest::binary>> = "hello"
       it("last bitstring segment", () => {
         const myBitstring = Type.bitstring("hello");


### PR DESCRIPTION
I came across this code that caused an unexpected match error once transpiled:

```elixir
  def put_markdown(%MDEx.Document{} = document, markdown, :top = _position) when is_binary(markdown) or is_list(markdown) do
    %{document | buffer: document.buffer ++ List.wrap(markdown)}
  end
```

It seems that the issue comes from the placeholder `_position` being the right side of the match instead of the left. Since that's valid Elixir, I think we should add a case for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pattern matching logic to handle placeholder behavior consistently.

* **Tests**
  * Added test coverage for pattern matching edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->