### PR TITLE
Port :lists.flatten/2 to JS

### DIFF
--- a/assets/js/erlang/lists.mjs
+++ b/assets/js/erlang/lists.mjs
@@ -153,6 +153,25 @@ const Erlang_Lists = {
   // End flatten/1
   // Deps: []
 
+  // Start flatten/2
+  "flatten/2": (list, tail) => {
+    if (!Type.isList(list) || !Type.isProperList(list) || !Type.isList(tail)) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":lists.flatten/2", [
+          list,
+          tail,
+        ]),
+      );
+    }
+
+    const flattened = Erlang_Lists["flatten/1"](list);
+    const data = flattened.data.concat(Type.isList(tail) ? tail.data : [tail]);
+
+    return Type.isProperList(tail) ? Type.list(data) : Type.improperList(data);
+  },
+  // End flatten/2
+  // Deps: [:lists.flatten/1]
+
   // Start foldl/3
   "foldl/3": function (fun, initialAcc, list) {
     if (!Type.isAnonymousFunction(fun) || fun.arity !== 2) {

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -88,6 +88,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:filename, :rootname, 2}, {:filename, :flatten, 1}},
     {{:filename, :split, 1}, {:erlang, :iolist_to_binary, 1}},
     {{:filename, :split, 1}, {:filename, :flatten, 1}},
+    {{:lists, :flatten, 2}, {:lists, :flatten, 1}},
     {{:lists, :seq, 2}, {:lists, :seq, 3}},
     {{:lists, :keymember, 3}, {:lists, :keyfind, 3}},
     {{:lists, :keysort, 2}, {:erlang, :element, 2}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/lists_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/lists_test.exs
@@ -250,6 +250,68 @@ defmodule Hologram.ExJsConsistency.Erlang.ListsTest do
     end
   end
 
+  describe "flatten/2" do
+    test "empty list and empty tail" do
+      assert :lists.flatten([], []) == []
+    end
+
+    test "empty list and non-empty tail" do
+      assert :lists.flatten([], [1, 2, 3]) == [1, 2, 3]
+    end
+
+    test "non-nested list and empty tail" do
+      assert :lists.flatten([1, 2, 3], []) == [1, 2, 3]
+    end
+
+    test "non-nested list and non-empty tail" do
+      assert :lists.flatten([1, 2, 3], [4, 5, 6]) == [1, 2, 3, 4, 5, 6]
+    end
+
+    test "nested list and non-empty tail" do
+      assert :lists.flatten([1, [2, [3, 4]]], [5, 6]) == [1, 2, 3, 4, 5, 6]
+    end
+
+    test "deeply nested empty lists" do
+      assert :lists.flatten([[], [[]]], [1, 2]) == [1, 2]
+    end
+
+    test "improper tail" do
+      assert :lists.flatten([1, 2], [3, 4 | 5]) == [1, 2, 3, 4 | 5]
+    end
+
+    test "raises FunctionClauseError if the first argument is not a list" do
+      expected_msg = build_function_clause_error_msg(":lists.flatten/2", [:abc, [1, 2]])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :lists.flatten(:abc, [1, 2])
+      end
+    end
+
+    test "raises FunctionClauseError if the first argument is an improper list" do
+      expected_msg = build_function_clause_error_msg(":lists.do_flatten/2", [3, [4, 5]])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :lists.flatten([1, 2 | 3], [4, 5])
+      end
+    end
+
+    test "raises FunctionClauseError if the first argument contains a nested improper list" do
+      expected_msg = build_function_clause_error_msg(":lists.do_flatten/2", [4, [5, 6]])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :lists.flatten([1, [2, 3 | 4]], [5, 6])
+      end
+    end
+
+    test "raises FunctionClauseError if the second argument is not a list" do
+      expected_msg = build_function_clause_error_msg(":lists.flatten/2", [[1, 2], :abc])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :lists.flatten([1, 2], :abc)
+      end
+    end
+  end
+
   describe "foldl/3" do
     setup do
       [fun: fn elem, acc -> [elem | acc] end]

--- a/test/javascript/erlang/lists_test.mjs
+++ b/test/javascript/erlang/lists_test.mjs
@@ -687,6 +687,199 @@ describe("Erlang_Lists", () => {
     });
   });
 
+  describe("flatten/2", () => {
+    const flatten = Erlang_Lists["flatten/2"];
+
+    it("empty list and empty tail", () => {
+      const result = flatten(emptyList, emptyList);
+
+      assert.deepStrictEqual(result, emptyList);
+    });
+
+    it("empty list and non-empty tail", () => {
+      const tail = Type.list([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const result = flatten(emptyList, tail);
+
+      assert.deepStrictEqual(result, tail);
+    });
+
+    it("non-nested list and empty tail", () => {
+      const list = Type.list([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const result = flatten(list, emptyList);
+
+      assert.deepStrictEqual(result, list);
+    });
+
+    it("non-nested list and non-empty tail", () => {
+      const list = Type.list([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const tail = Type.list([
+        Type.integer(4),
+        Type.integer(5),
+        Type.integer(6),
+      ]);
+
+      const result = flatten(list, tail);
+
+      const expected = Type.list([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+        Type.integer(4),
+        Type.integer(5),
+        Type.integer(6),
+      ]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("nested list and non-empty tail", () => {
+      const list = Type.list([
+        Type.integer(1),
+        Type.list([
+          Type.integer(2),
+          Type.list([Type.integer(3), Type.integer(4)]),
+        ]),
+      ]);
+
+      const tail = Type.list([Type.integer(5), Type.integer(6)]);
+
+      const result = flatten(list, tail);
+
+      const expected = Type.list([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+        Type.integer(4),
+        Type.integer(5),
+        Type.integer(6),
+      ]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("deeply nested empty lists", () => {
+      const list = Type.list([emptyList, Type.list([emptyList])]);
+      const tail = Type.list([Type.integer(1), Type.integer(2)]);
+
+      const result = flatten(list, tail);
+      const expected = Type.list([Type.integer(1), Type.integer(2)]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("improper tail", () => {
+      const list = Type.list([Type.integer(1), Type.integer(2)]);
+
+      const tail = Type.improperList([
+        Type.integer(3),
+        Type.integer(4),
+        Type.integer(5),
+      ]);
+
+      const result = flatten(list, tail);
+
+      const expected = Type.improperList([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+        Type.integer(4),
+        Type.integer(5),
+      ]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("raises FunctionClauseError if the first argument is not a list", () => {
+      const list = Type.atom("abc");
+      const tail = Type.list([Type.integer(1), Type.integer(2)]);
+
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.flatten/2",
+        [list, tail],
+      );
+
+      assertBoxedError(
+        () => flatten(list, tail),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+
+    it("raises FunctionClauseError if the first argument is an improper list", () => {
+      const list = Type.improperList([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const tail = Type.list([Type.integer(4), Type.integer(5)]);
+
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.flatten/2",
+        [list, tail],
+      );
+
+      assertBoxedError(
+        () => flatten(list, tail),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+
+    it("raises FunctionClauseError if the first argument contains a nested improper list", () => {
+      const nestedImproperList = Type.improperList([
+        Type.integer(2),
+        Type.integer(3),
+        Type.integer(4),
+      ]);
+
+      const list = Type.list([Type.integer(1), nestedImproperList]);
+      const tail = Type.list([Type.integer(5), Type.integer(6)]);
+
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.flatten/1",
+        [nestedImproperList],
+      );
+
+      assertBoxedError(
+        () => flatten(list, tail),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+
+    it("raises FunctionClauseError if the second argument is not a list", () => {
+      const list = Type.list([Type.integer(1), Type.integer(2)]);
+      const tail = Type.atom("abc");
+
+      const expectedMessage = Interpreter.buildFunctionClauseErrorMsg(
+        ":lists.flatten/2",
+        [list, tail],
+      );
+
+      assertBoxedError(
+        () => flatten(list, tail),
+        "FunctionClauseError",
+        expectedMessage,
+      );
+    });
+  });
+
   describe("foldl/3", () => {
     const foldl = Erlang_Lists["foldl/3"];
 


### PR DESCRIPTION
Closes #554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `flatten/2` function to Erlang lists module, enabling flattening of a list with a specified tail appended to the result.

* **Tests**
  * Expanded test coverage for the new `flatten/2` function across multiple test suites, including validation of input parameters and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->