### PR TITLE
Port :erlang.round/1 to JS

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -1898,6 +1898,28 @@ const Erlang = {
   // End rem/2
   // Deps: []
 
+  // Start round/1
+  "round/1": (number) => {
+    if (!Type.isNumber(number)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(1, "not a number"),
+      );
+    }
+
+    if (Type.isInteger(number)) {
+      return number;
+    }
+
+    // Erlang rounds half away from zero (5.5 -> 6, -5.5 -> -6)
+    // JavaScript Math.round rounds half toward positive infinity (5.5 -> 6, -5.5 -> -5)
+    // Use sign * round(abs) to get correct behavior
+    // Adding 0 converts -0 to 0
+    const value = number.value;
+    return Type.integer(Math.sign(value) * Math.round(Math.abs(value)) + 0);
+  },
+  // End round/1
+  // Deps: []
+
   // Start setelement/3
   "setelement/3": (index, tuple, value) => {
     if (!Type.isInteger(index)) {

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -4044,6 +4044,95 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "round/1" do
+    test "rounds positive float with fractional part less than 0.5 down" do
+      assert :erlang.round(1.23) == 1
+    end
+
+    test "rounds positive float with fractional part greater than 0.5 up" do
+      assert :erlang.round(1.67) == 2
+    end
+
+    test "rounds positive float with fractional part equal to 0.5 away from zero (up)" do
+      assert :erlang.round(5.5) == 6
+    end
+
+    test "rounds negative float with fractional part less than 0.5 up toward zero" do
+      assert :erlang.round(-1.23) == -1
+    end
+
+    test "rounds negative float with fractional part greater than 0.5 down away from zero" do
+      assert :erlang.round(-1.67) == -2
+    end
+
+    test "rounds negative float with fractional part equal to 0.5 away from zero (down)" do
+      assert :erlang.round(-5.5) == -6
+    end
+
+    test "keeps positive float without fractional part unchanged" do
+      assert :erlang.round(1.0) == 1
+    end
+
+    test "keeps negative float without fractional part unchanged" do
+      assert :erlang.round(-1.0) == -1
+    end
+
+    test "keeps signed negative zero float unchanged" do
+      assert :erlang.round(-0.0) == 0
+    end
+
+    test "keeps signed positive zero float unchanged" do
+      assert :erlang.round(+0.0) == 0
+    end
+
+    test "keeps unsigned zero float unchanged" do
+      assert :erlang.round(0.0) == 0
+    end
+
+    test "rounds 0.5 away from zero" do
+      assert :erlang.round(0.5) == 1
+    end
+
+    test "rounds -0.5 away from zero" do
+      assert :erlang.round(-0.5) == -1
+    end
+
+    test "keeps positive integer unchanged" do
+      assert :erlang.round(1) == 1
+    end
+
+    test "keeps negative integer unchanged" do
+      assert :erlang.round(-1) == -1
+    end
+
+    test "keeps zero integer unchanged" do
+      assert :erlang.round(0) == 0
+    end
+
+    test "handles MAX_SAFE_INTEGER float" do
+      # Number.MAX_SAFE_INTEGER == 9_007_199_254_740_991
+      assert :erlang.round(9_007_199_254_740_991.0) == 9_007_199_254_740_991
+    end
+
+    test "handles MIN_SAFE_INTEGER float" do
+      # Number.MIN_SAFE_INTEGER == -9_007_199_254_740_991
+      assert :erlang.round(-9_007_199_254_740_991.0) == -9_007_199_254_740_991
+    end
+
+    test "handles large float that loses precision" do
+      # This demonstrates that float representation limits apply before rounding
+      # 36_028_797_018_963_969.0 cannot be represented exactly as a float
+      # It's stored as 36_028_797_018_963_968.0
+      assert :erlang.round(36_028_797_018_963_969.0) == 36_028_797_018_963_968
+    end
+
+    test "raises ArgumentError if the argument is not a number" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not a number"),
+                   {:erlang, :round, [:abc]}
+    end
+  end
+
   describe "setelement/3" do
     test "replaces a middle element" do
       assert :erlang.setelement(2, {1, 2, 3}, :a) === {1, :a, 3}

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -6662,6 +6662,147 @@ describe("Erlang", () => {
     });
   });
 
+  describe("round/1", () => {
+    const testedFun = Erlang["round/1"];
+
+    it("rounds positive float with fractional part less than 0.5 down", () => {
+      const result = testedFun(Type.float(1.23));
+
+      assert.deepStrictEqual(result, integer1);
+    });
+
+    it("rounds positive float with fractional part greater than 0.5 up", () => {
+      const result = testedFun(Type.float(1.67));
+
+      assert.deepStrictEqual(result, integer2);
+    });
+
+    it("rounds positive float with fractional part equal to 0.5 away from zero (up)", () => {
+      const result = testedFun(Type.float(5.5));
+
+      assert.deepStrictEqual(result, integer6);
+    });
+
+    it("rounds negative float with fractional part less than 0.5 up toward zero", () => {
+      const result = testedFun(Type.float(-1.23));
+      const expected = Type.integer(-1);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("rounds negative float with fractional part greater than 0.5 down away from zero", () => {
+      const result = testedFun(Type.float(-1.67));
+      const expected = Type.integer(-2);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("rounds negative float with fractional part equal to 0.5 away from zero (down)", () => {
+      const result = testedFun(Type.float(-5.5));
+      const expected = Type.integer(-6);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("keeps positive float without fractional part unchanged", () => {
+      const result = testedFun(Type.float(1.0));
+
+      assert.deepStrictEqual(result, integer1);
+    });
+
+    it("keeps negative float without fractional part unchanged", () => {
+      const result = testedFun(Type.float(-1.0));
+      const expected = Type.integer(-1);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("keeps signed negative zero float unchanged", () => {
+      const result = testedFun(Type.float(-0.0));
+
+      assert.deepStrictEqual(result, integer0);
+    });
+
+    it("keeps signed positive zero float unchanged", () => {
+      const result = testedFun(Type.float(+0.0));
+
+      assert.deepStrictEqual(result, integer0);
+    });
+
+    it("keeps unsigned zero float unchanged", () => {
+      const result = testedFun(Type.float(0.0));
+
+      assert.deepStrictEqual(result, integer0);
+    });
+
+    it("rounds 0.5 away from zero", () => {
+      const result = testedFun(Type.float(0.5));
+
+      assert.deepStrictEqual(result, integer1);
+    });
+
+    it("rounds -0.5 away from zero", () => {
+      const result = testedFun(Type.float(-0.5));
+      const expected = Type.integer(-1);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("keeps positive integer unchanged", () => {
+      const result = testedFun(integer1);
+
+      assert.deepStrictEqual(result, integer1);
+    });
+
+    it("keeps negative integer unchanged", () => {
+      const integer = Type.integer(-1);
+      const result = testedFun(integer);
+
+      assert.deepStrictEqual(result, integer);
+    });
+
+    it("keeps zero integer unchanged", () => {
+      const result = testedFun(integer0);
+
+      assert.deepStrictEqual(result, integer0);
+    });
+
+    it("handles MAX_SAFE_INTEGER float", () => {
+      // Number.MAX_SAFE_INTEGER == 9_007_199_254_740_991
+      const result = testedFun(Type.float(9_007_199_254_740_991.0));
+      const expected = Type.integer(9_007_199_254_740_991n);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("handles MIN_SAFE_INTEGER float", () => {
+      // Number.MIN_SAFE_INTEGER == -9_007_199_254_740_991
+      const result = testedFun(Type.float(-9_007_199_254_740_991.0));
+      const expected = Type.integer(-9_007_199_254_740_991n);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("handles large float that loses precision", () => {
+      // This demonstrates that float representation limits apply before rounding
+      // 36_028_797_018_963_969.0 cannot be represented exactly as a float
+      // It's stored as 36_028_797_018_963_968.0
+      // eslint-disable-next-line no-loss-of-precision
+      const result = testedFun(Type.float(36_028_797_018_963_969.0));
+      const expected = Type.integer(36_028_797_018_963_968n);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("raises ArgumentError if the argument is not a number", () => {
+      assertBoxedError(
+        () => testedFun(Type.atom("abc")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not a number"),
+      );
+    });
+  });
+
   describe("setelement/3", () => {
     const setelement = Erlang["setelement/3"];
 
@@ -7050,9 +7191,9 @@ describe("Erlang", () => {
 
     it("demonstrates floating-point precision limits for large numbers", () => {
       // eslint-disable-next-line no-loss-of-precision
-      const result = testedFun(Type.float(36028797018963969.0));
+      const result = testedFun(Type.float(36_028_797_018_963_969.0));
 
-      const expected = Type.integer(36028797018963968n);
+      const expected = Type.integer(36_028_797_018_963_968n);
 
       assert.deepStrictEqual(result, expected);
     });


### PR DESCRIPTION
Closes #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `round/1` function to Erlang support for rounding numeric values to the nearest integer with consistent behavior.

* **Tests**
  * Added extensive test coverage including positive and negative numbers, fractional edge cases, safe integer boundaries, zero variations, and validation of error handling for non-numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->