### PR TITLE
Port :erlang.fun_info/2 to JS

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -1176,6 +1176,42 @@ const Erlang = {
   // End fun_info/1
   // Deps: []
 
+  // Start fun_info/2
+  "fun_info/2": (fun, item) => {
+    const validItems = new Set([
+      "arity",
+      "env",
+      "index",
+      "module",
+      "name",
+      "new_index",
+      "new_uniq",
+      "pid",
+      "type",
+      "uniq",
+    ]);
+
+    const info = Erlang["fun_info/1"](fun);
+
+    if (!Type.isAtom(item) || !validItems.has(item.value)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(2, "invalid item"),
+      );
+    }
+
+    const result = info.data.find(
+      (tuple) => tuple.data[0].value === item.value,
+    );
+
+    if (result === undefined) {
+      return Type.tuple([item, Type.atom("undefined")]);
+    }
+
+    return result;
+  },
+  // End fun_info/2
+  // Deps: [:erlang.fun_info/1]
+
   // Start hd/1
   "hd/1": (list) => {
     if (!Type.isList(list) || list.data.length === 0) {

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -52,6 +52,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:erlang, :convert_time_unit, 3}, {:erlang, :_validate_time_unit, 2}},
     {{:erlang, :error, 1}, {:erlang, :error, 2}},
     {{:erlang, :float_to_list, 2}, {:erlang, :float_to_binary, 2}},
+    {{:erlang, :fun_info, 2}, {:erlang, :fun_info, 1}},
     {{:erlang, :integer_to_binary, 1}, {:erlang, :integer_to_binary, 2}},
     {{:erlang, :integer_to_list, 1}, {:erlang, :integer_to_list, 2}},
     {{:erlang, :iolist_to_binary, 1}, {:lists, :flatten, 1}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -3179,6 +3179,48 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "fun_info/2" do
+    test "external function, item present" do
+      assert :erlang.fun_info(&Module1.fun_1/1, :arity) == {:arity, 1}
+    end
+
+    test "external function, item available only for local functions returns undefined" do
+      assert :erlang.fun_info(&Module1.fun_1/1, :pid) == {:pid, :undefined}
+    end
+
+    test "local function, item present" do
+      fun = fn x -> x + 1 end
+
+      assert :erlang.fun_info(fun, :arity) == {:arity, 1}
+    end
+
+    test "raises ArgumentError if the first arg is not a fun" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not a fun"),
+                   {:erlang, :fun_info, [:abc, :arity]}
+    end
+
+    test "raises ArgumentError if the second arg is not an atom" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(2, "invalid item"),
+                   {:erlang, :fun_info, [&Module1.fun_1/1, 123]}
+    end
+
+    test "external function, invalid item raises ArgumentError" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(2, "invalid item"),
+                   {:erlang, :fun_info, [&Module1.fun_1/1, :invalid_item]}
+    end
+
+    test "local function, invalid item raises ArgumentError" do
+      fun = fn x -> x + 1 end
+
+      assert_error ArgumentError,
+                   build_argument_error_msg(2, "invalid item"),
+                   {:erlang, :fun_info, [fun, :invalid_item]}
+    end
+  end
+
   describe "hd/1" do
     test "returns the first item in the list" do
       assert :erlang.hd([1, 2, 3]) === 1

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -5037,6 +5037,127 @@ describe("Erlang", () => {
     });
   });
 
+  describe("fun_info/2", () => {
+    const fun_info = Erlang["fun_info/2"];
+
+    it("external function, item present", () => {
+      const fun = Type.functionCapture(
+        "Hologram.Test.Fixtures.ExJsConsistency.Erlang.Module1",
+        "fun_1",
+        1,
+        [],
+        contextFixture(),
+      );
+
+      const result = fun_info(fun, Type.atom("arity"));
+      const expected = Type.tuple([Type.atom("arity"), Type.integer(1)]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("external function, item available only for local functions returns undefined", () => {
+      const fun = Type.functionCapture(
+        "Hologram.Test.Fixtures.ExJsConsistency.Erlang.Module1",
+        "fun_1",
+        1,
+        [],
+        contextFixture(),
+      );
+
+      const result = fun_info(fun, Type.atom("pid"));
+      const expected = Type.tuple([Type.atom("pid"), Type.atom("undefined")]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("local function, item present", () => {
+      const fun = Type.anonymousFunction(
+        1,
+        [
+          {
+            params: (_context) => [Type.variablePattern("x")],
+            guards: [],
+            body: (context) => Erlang["+/2"](context.vars.x, Type.integer(1)),
+          },
+        ],
+        contextFixture({
+          module: Type.alias(
+            "Hologram.Test.Fixtures.ExJsConsistency.Erlang.Module1",
+          ),
+        }),
+      );
+
+      const result = fun_info(fun, Type.atom("arity"));
+      const expected = Type.tuple([Type.atom("arity"), Type.integer(1)]);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("raises ArgumentError if the first arg is not a fun", () => {
+      assertBoxedError(
+        () => fun_info(Type.atom("abc"), Type.atom("arity")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not a fun"),
+      );
+    });
+
+    it("raises ArgumentError if the second arg is not an atom", () => {
+      const fun = Type.functionCapture(
+        "Hologram.Test.Fixtures.ExJsConsistency.Erlang.Module1",
+        "fun_1",
+        1,
+        [],
+        contextFixture(),
+      );
+
+      assertBoxedError(
+        () => fun_info(fun, Type.integer(123)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(2, "invalid item"),
+      );
+    });
+
+    it("external function, invalid item raises ArgumentError", () => {
+      const fun = Type.functionCapture(
+        "Hologram.Test.Fixtures.ExJsConsistency.Erlang.Module1",
+        "fun_1",
+        1,
+        [],
+        contextFixture(),
+      );
+
+      assertBoxedError(
+        () => fun_info(fun, Type.atom("invalid_item")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(2, "invalid item"),
+      );
+    });
+
+    it("local function, invalid item raises ArgumentError", () => {
+      const fun = Type.anonymousFunction(
+        1,
+        [
+          {
+            params: (_context) => [Type.variablePattern("x")],
+            guards: [],
+            body: (context) => Erlang["+/2"](context.vars.x, Type.integer(1)),
+          },
+        ],
+        contextFixture({
+          module: Type.alias(
+            "Hologram.Test.Fixtures.ExJsConsistency.Erlang.Module1",
+          ),
+        }),
+      );
+
+      assertBoxedError(
+        () => fun_info(fun, Type.atom("invalid_item")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(2, "invalid item"),
+      );
+    });
+  });
+
   describe("hd/1", () => {
     const hd = Erlang["hd/1"];
 


### PR DESCRIPTION
Closes #555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `fun_info/2` function that retrieves specific information about a function by key (e.g., arity, module, name, type), complementing the existing single-argument variant.

* **Tests**
  * Added comprehensive test coverage for the new function across both Erlang and Elixir implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->