### PR TITLE
Port :erlang.append_element/2 to JS

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -296,6 +296,19 @@ const Erlang = {
   // End andalso/2
   // Deps: []
 
+  // Start append_element/2
+  "append_element/2": (tuple, term) => {
+    if (!Type.isTuple(tuple)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(1, "not a tuple"),
+      );
+    }
+
+    return Type.tuple([...tuple.data, term]);
+  },
+  // End append_element/2
+  // Deps: []
+
   // Start apply/2
   "apply/2": (fun, args) => {
     if (!Type.isAnonymousFunction(fun)) {

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -1280,6 +1280,26 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "append_element/2" do
+    test "appends an element to an empty tuple" do
+      assert :erlang.append_element({}, 1) == {1}
+    end
+
+    test "appends an element to a single-element tuple" do
+      assert :erlang.append_element({1}, 2) == {1, 2}
+    end
+
+    test "appends an element to a tuple with multiple elements" do
+      assert :erlang.append_element({:one, :two}, :three) == {:one, :two, :three}
+    end
+
+    test "raises ArgumentError if the first argument is not a tuple" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not a tuple"),
+                   {:erlang, :append_element, [:abc, 1]}
+    end
+  end
+
   describe "apply/2" do
     setup do
       [

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -1475,6 +1475,48 @@ describe("Erlang", () => {
     });
   });
 
+  describe("append_element/2", () => {
+    const append_element = Erlang["append_element/2"];
+
+    it("appends an element to an empty tuple", () => {
+      const result = append_element(Type.tuple(), Type.integer(1));
+
+      assert.deepStrictEqual(result, Type.tuple([Type.integer(1)]));
+    });
+
+    it("appends an element to a single-element tuple", () => {
+      const result = append_element(
+        Type.tuple([Type.integer(1)]),
+        Type.integer(2),
+      );
+
+      assert.deepStrictEqual(
+        result,
+        Type.tuple([Type.integer(1), Type.integer(2)]),
+      );
+    });
+
+    it("appends an element to a tuple with multiple elements", () => {
+      const result = append_element(
+        Type.tuple([Type.atom("one"), Type.atom("two")]),
+        Type.atom("three"),
+      );
+
+      assert.deepStrictEqual(
+        result,
+        Type.tuple([Type.atom("one"), Type.atom("two"), Type.atom("three")]),
+      );
+    });
+
+    it("raises ArgumentError if the first argument is not a tuple", () => {
+      assertBoxedError(
+        () => append_element(Type.atom("abc"), Type.integer(1)),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not a tuple"),
+      );
+    });
+  });
+
   describe("apply/2", () => {
     const apply = Erlang["apply/2"];
 


### PR DESCRIPTION
Closes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `append_element/2` function to append elements to tuples with validation that raises an error for invalid inputs.

* **Tests**
  * Added comprehensive test coverage for tuple appending functionality across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->