### PR TITLE
Port :sets.intersection/2 to JS

### DIFF
--- a/assets/js/erlang/sets.mjs
+++ b/assets/js/erlang/sets.mjs
@@ -147,6 +147,30 @@ const Erlang_Sets = {
   // End from_list/2
   // Deps: [:maps.from_keys/2, :sets._validate_opts/1]
 
+  // Start intersection/2
+  "intersection/2": (set1, set2) => {
+    if (!Type.isMap(set1) || !Type.isMap(set2)) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":sets.size/1", [
+          !Type.isMap(set1) ? set1 : set2,
+        ]),
+      );
+    }
+
+    const encodedKeys1 = new Set(Object.keys(set1.data));
+    const encodedKeys2 = new Set(Object.keys(set2.data));
+    const intersectedKeys = encodedKeys1.intersection(encodedKeys2);
+
+    const data = {};
+    for (const encodedKey of intersectedKeys) {
+      data[encodedKey] = set1.data[encodedKey];
+    }
+
+    return {type: "map", data};
+  },
+  // End intersection/2
+  // Deps: []
+
   // Start is_disjoint/2
   "is_disjoint/2": (set1, set2) => {
     if (!Type.isMap(set1) || !Type.isMap(set2)) {

--- a/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
@@ -293,6 +293,70 @@ defmodule Hologram.ExJsConsistency.Erlang.SetsTest do
     end
   end
 
+  describe "intersection/2" do
+    setup do
+      [
+        empty_set: :sets.new(version: 2),
+        set_123: :sets.from_list([1, 2, 3], version: 2)
+      ]
+    end
+
+    test "returns the intersection of two sets with common elements", %{set_123: set_123} do
+      set_234 = :sets.from_list([2, 3, 4], version: 2)
+
+      result = :sets.intersection(set_123, set_234)
+      expected = :sets.from_list([2, 3], version: 2)
+
+      assert result == expected
+    end
+
+    test "returns an empty set if sets have no common elements" do
+      set_12 = :sets.from_list([1, 2], version: 2)
+      set_3 = :sets.from_list([3], version: 2)
+
+      assert :sets.intersection(set_12, set_3) == :sets.new(version: 2)
+    end
+
+    test "returns an empty set if both sets are empty", %{empty_set: empty_set} do
+      assert :sets.intersection(empty_set, empty_set) == empty_set
+    end
+
+    test "returns an empty set if first set is empty", %{empty_set: empty_set, set_123: set_123} do
+      assert :sets.intersection(empty_set, set_123) == empty_set
+    end
+
+    test "returns an empty set if second set is empty", %{empty_set: empty_set, set_123: set_123} do
+      assert :sets.intersection(set_123, empty_set) == empty_set
+    end
+
+    test "returns the same set if sets are identical", %{set_123: set_123} do
+      assert :sets.intersection(set_123, set_123) == set_123
+    end
+
+    test "uses strict matching (integer vs float)" do
+      set_int = :sets.from_list([1], version: 2)
+      set_float = :sets.from_list([1.0], version: 2)
+
+      assert :sets.intersection(set_int, set_float) == :sets.new(version: 2)
+    end
+
+    test "raises FunctionClauseError if the first argument is not a set", %{set_123: set_123} do
+      expected_msg = build_function_clause_error_msg(":sets.size/1", [:abc])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :sets.intersection(:abc, set_123)
+      end
+    end
+
+    test "raises FunctionClauseError if the second argument is not a set", %{set_123: set_123} do
+      expected_msg = build_function_clause_error_msg(":sets.size/1", [:abc])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :sets.intersection(set_123, :abc)
+      end
+    end
+  end
+
   describe "is_disjoint/2" do
     setup do
       [

--- a/test/javascript/erlang/sets_test.mjs
+++ b/test/javascript/erlang/sets_test.mjs
@@ -568,6 +568,81 @@ describe("Erlang_Sets", () => {
     });
   });
 
+  describe("intersection/2", () => {
+    const intersection_2 = Erlang_Sets["intersection/2"];
+    const from_list_2 = Erlang_Sets["from_list/2"];
+
+    it("returns the intersection of two sets with common elements", () => {
+      const set234 = from_list_2(
+        Type.list([integer2, integer3, Type.integer(4)]),
+        opts,
+      );
+
+      const result = intersection_2(set123, set234);
+      const expected = from_list_2(Type.list([integer2, integer3]), opts);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("returns an empty set if sets have no common elements", () => {
+      const set12 = from_list_2(Type.list([integer1, integer2]), opts);
+      const set3 = from_list_2(Type.list([integer3]), opts);
+
+      const result = intersection_2(set12, set3);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("returns an empty set if both sets are empty", () => {
+      const result = intersection_2(emptySet, emptySet);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("returns an empty set if first set is empty", () => {
+      const result = intersection_2(emptySet, set123);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("returns an empty set if second set is empty", () => {
+      const result = intersection_2(set123, emptySet);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("returns the same set if sets are identical", () => {
+      const result = intersection_2(set123, set123);
+
+      assert.deepStrictEqual(result, set123);
+    });
+
+    it("uses strict matching (integer vs float)", () => {
+      const setInt = from_list_2(Type.list([integer1]), opts);
+      const setFloat = from_list_2(Type.list([float1]), opts);
+
+      const result = intersection_2(setInt, setFloat);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("raises FunctionClauseError if the first argument is not a set", () => {
+      assertBoxedError(
+        () => intersection_2(atomAbc, set123),
+        "FunctionClauseError",
+        Interpreter.buildFunctionClauseErrorMsg(":sets.size/1", [atomAbc]),
+      );
+    });
+
+    it("raises FunctionClauseError if the second argument is not a set", () => {
+      assertBoxedError(
+        () => intersection_2(set123, atomAbc),
+        "FunctionClauseError",
+        Interpreter.buildFunctionClauseErrorMsg(":sets.size/1", [atomAbc]),
+      );
+    });
+  });
+
   describe("is_disjoint/2", () => {
     const is_disjoint_2 = Erlang_Sets["is_disjoint/2"];
     const from_list_2 = Erlang_Sets["from_list/2"];


### PR DESCRIPTION
Closes #437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `intersection/2` function to Erlang Sets module for set intersection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->