### PR TITLE
Port :sets.subtract/2 to JS

### DIFF
--- a/assets/js/erlang/sets.mjs
+++ b/assets/js/erlang/sets.mjs
@@ -258,6 +258,43 @@ const Erlang_Sets = {
   // End size/1
   // Deps: [:erlang.map_size/1]
 
+  // Start subtract/2
+  "subtract/2": (set1, set2) => {
+    if (!Type.isMap(set1)) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":sets.filter/2"),
+      );
+    }
+
+    if (Object.keys(set1.data).length === 0) {
+      return Type.map();
+    }
+
+    if (!Type.isMap(set2)) {
+      const firstElement = Object.values(set1.data)[0][0];
+
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":sets.is_element/2", [
+          firstElement,
+          set2,
+        ]),
+      );
+    }
+
+    const encodedKeys1 = new Set(Object.keys(set1.data));
+    const encodedKeys2 = new Set(Object.keys(set2.data));
+    const subtractedKeys = encodedKeys1.difference(encodedKeys2);
+
+    const data = {};
+    for (const encodedKey of subtractedKeys) {
+      data[encodedKey] = set1.data[encodedKey];
+    }
+
+    return {type: "map", data};
+  },
+  // End subtract/2
+  // Deps: []
+
   // Start to_list/1
   "to_list/1": (set) => {
     if (!Type.isMap(set)) {

--- a/test/javascript/erlang/sets_test.mjs
+++ b/test/javascript/erlang/sets_test.mjs
@@ -927,6 +927,84 @@ describe("Erlang_Sets", () => {
     });
   });
 
+  describe("subtract/2", () => {
+    const subtract_2 = Erlang_Sets["subtract/2"];
+    const from_list_2 = Erlang_Sets["from_list/2"];
+
+    it("returns elements in the first set that are not in the second set", () => {
+      const set234 = from_list_2(
+        Type.list([integer2, integer3, Type.integer(4)]),
+        opts,
+      );
+
+      const result = subtract_2(set123, set234);
+      const expected = from_list_2(Type.list([integer1]), opts);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("returns the first set if sets have no common elements", () => {
+      const set12 = from_list_2(Type.list([integer1, integer2]), opts);
+      const set3 = from_list_2(Type.list([integer3]), opts);
+
+      const result = subtract_2(set12, set3);
+
+      assert.deepStrictEqual(result, set12);
+    });
+
+    it("returns an empty set if both sets are empty", () => {
+      const result = subtract_2(emptySet, emptySet);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("returns an empty set if first set is empty", () => {
+      const result = subtract_2(emptySet, set123);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("returns the first set if second set is empty", () => {
+      const result = subtract_2(set123, emptySet);
+
+      assert.deepStrictEqual(result, set123);
+    });
+
+    it("returns an empty set if sets are identical", () => {
+      const result = subtract_2(set123, set123);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("uses strict matching (integer vs float)", () => {
+      const setInt = from_list_2(Type.list([integer1]), opts);
+      const setFloat = from_list_2(Type.list([float1]), opts);
+
+      const result = subtract_2(setInt, setFloat);
+
+      assert.deepStrictEqual(result, setInt);
+    });
+
+    it("raises FunctionClauseError if the first argument is not a set", () => {
+      assertBoxedError(
+        () => subtract_2(atomAbc, set123),
+        "FunctionClauseError",
+        Interpreter.buildFunctionClauseErrorMsg(":sets.filter/2"),
+      );
+    });
+
+    it("raises FunctionClauseError if the second argument is not a set", () => {
+      assertBoxedError(
+        () => subtract_2(set123, atomAbc),
+        "FunctionClauseError",
+        Interpreter.buildFunctionClauseErrorMsg(":sets.is_element/2", [
+          integer1,
+          atomAbc,
+        ]),
+      );
+    });
+  });
+
   describe("to_list/1", () => {
     const to_list = Erlang_Sets["to_list/1"];
 


### PR DESCRIPTION
Closes #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added set subtraction operation to compute the difference between two sets, returning elements that exist in the first set but not in the second set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->