### PR TITLE
Port :erlang.map_get/2 to JS

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -1,6 +1,7 @@
 "use strict";
 
 import Bitstring from "../bitstring.mjs";
+import Erlang_Maps from "../erlang/maps.mjs";
 import Erlang_Os from "../erlang/os.mjs";
 import ERTS from "../erts.mjs";
 import HologramBoxedError from "../errors/boxed_error.mjs";
@@ -2039,6 +2040,13 @@ const Erlang = {
   },
   // End make_tuple/2
   // Deps: []
+
+  // Start map_get/2
+  "map_get/2": (key, map) => {
+    return Erlang_Maps["get/2"](key, map);
+  },
+  // End map_get/2
+  // Deps: [:maps.get/2]
 
   // Start map_size/1
   "map_size/1": (map) => {

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -59,6 +59,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:erlang, :is_map_key, 2}, {:maps, :is_key, 2}},
     {{:erlang, :list_to_existing_atom, 1}, {:erlang, :list_to_atom, 1}},
     {{:erlang, :list_to_integer, 1}, {:erlang, :list_to_integer, 2}},
+    {{:erlang, :map_get, 2}, {:maps, :get, 2}},
     {{:erlang, :monotonic_time, 1}, {:erlang, :_validate_time_unit, 2}},
     {{:erlang, :monotonic_time, 1}, {:erlang, :convert_time_unit, 3}},
     {{:erlang, :monotonic_time, 1}, {:erlang, :monotonic_time, 0}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -4471,6 +4471,20 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "map_get/2" do
+    test "returns the value associated with the given key if map contains the key" do
+      assert :erlang.map_get(:b, %{a: 1, b: 2}) == 2
+    end
+
+    test "raises BadMapError if the second argument is not a map" do
+      assert_error BadMapError, "expected a map, got: 1", {:erlang, :map_get, [:a, 1]}
+    end
+
+    test "raises KeyError if the map doesn't contain the given key" do
+      assert_error KeyError, build_key_error_msg(:a, %{}), {:erlang, :map_get, [:a, %{}]}
+    end
+  end
+
   describe "map_size/1" do
     test "returns the number of items in the map" do
       assert :erlang.map_size(%{a: 1, b: 2}) == 2

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -7836,6 +7836,41 @@ describe("Erlang", () => {
     });
   });
 
+  describe("map_get/2", () => {
+    const map_get = Erlang["map_get/2"];
+
+    it("returns the value associated with the given key if map contains the key", () => {
+      const key = Type.atom("b");
+      const value = Type.integer(2);
+
+      const map = Type.map([
+        [Type.atom("a"), Type.integer(1)],
+        [key, value],
+      ]);
+
+      assert.deepStrictEqual(map_get(key, map), value);
+    });
+
+    it("raises BadMapError if the second argument is not a map", () => {
+      assertBoxedError(
+        () => map_get(Type.atom("a"), Type.integer(1)),
+        "BadMapError",
+        "expected a map, got: 1",
+      );
+    });
+
+    it("raises KeyError if the map doesn't contain the given key", () => {
+      const key = Type.atom("a");
+      const map = Type.map();
+
+      assertBoxedError(
+        () => map_get(key, map),
+        "KeyError",
+        Interpreter.buildKeyErrorMsg(key, map),
+      );
+    });
+  });
+
   describe("map_size/1", () => {
     const map_size = Erlang["map_size/1"];
 


### PR DESCRIPTION
Closes #395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `map_get/2` function to the Erlang module for retrieving values from maps, with proper handling of missing keys and invalid inputs.

* **Tests**
  * Added comprehensive test coverage for the new map retrieval function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->