### PR TITLE
Port :erlang.tuple_size/1 to JS

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -2405,6 +2405,19 @@ const Erlang = {
   // End trunc/1
   // Deps: []
 
+  // Start tuple_size/1
+  "tuple_size/1": (tuple) => {
+    if (!Type.isTuple(tuple)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(1, "not a tuple"),
+      );
+    }
+
+    return Type.integer(tuple.data.length);
+  },
+  // End tuple_size/1
+  // Deps: []
+
   // Start tuple_to_list/1
   "tuple_to_list/1": (tuple) => {
     if (!Type.isTuple(tuple)) {

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -5030,6 +5030,22 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "tuple_size/1" do
+    test "returns the number of elements in the tuple" do
+      assert :erlang.tuple_size({1, 2, 3}) == 3
+    end
+
+    test "returns 0 for an empty tuple" do
+      assert :erlang.tuple_size({}) == 0
+    end
+
+    test "raises ArgumentError if the argument is not a tuple" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not a tuple"),
+                   {:erlang, :tuple_size, [:abc]}
+    end
+  end
+
   describe "tuple_to_list/1" do
     test "returns a list corresponding to the given tuple" do
       assert :erlang.tuple_to_list({1, 2, 3}) == [1, 2, 3]

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -8796,6 +8796,32 @@ describe("Erlang", () => {
     });
   });
 
+  describe("tuple_size/1", () => {
+    const tuple_size = Erlang["tuple_size/1"];
+
+    it("returns the number of elements in the tuple", () => {
+      const tuple = Type.tuple([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      assert.deepStrictEqual(tuple_size(tuple), Type.integer(3));
+    });
+
+    it("returns 0 for an empty tuple", () => {
+      assert.deepStrictEqual(tuple_size(Type.tuple()), Type.integer(0));
+    });
+
+    it("raises ArgumentError if the argument is not a tuple", () => {
+      assertBoxedError(
+        () => tuple_size(Type.atom("abc")),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not a tuple"),
+      );
+    });
+  });
+
   describe("tuple_to_list/1", () => {
     const tuple_to_list = Erlang["tuple_to_list/1"];
 


### PR DESCRIPTION
Closes #330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tuple_size functionality to retrieve the number of elements in tuples, with built-in validation that raises errors for non-tuple inputs.

* **Tests**
  * Comprehensive test coverage added across implementations validating tuple size retrieval for various scenarios, including empty tuples and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->