### PR TITLE
Port :sets.union/2 to JS

### DIFF
--- a/assets/js/erlang/sets.mjs
+++ b/assets/js/erlang/sets.mjs
@@ -307,6 +307,31 @@ const Erlang_Sets = {
   },
   // End to_list/1
   // Deps: [:maps.keys/1]
+
+  // Start union/2
+  "union/2": (set1, set2) => {
+    if (!Type.isMap(set1) || !Type.isMap(set2)) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":sets.size/1", [
+          !Type.isMap(set1) ? set1 : set2,
+        ]),
+      );
+    }
+
+    const encodedKeys1 = new Set(Object.keys(set1.data));
+    const encodedKeys2 = new Set(Object.keys(set2.data));
+    const unionedKeys = encodedKeys1.union(encodedKeys2);
+
+    const data = {};
+    for (const encodedKey of unionedKeys) {
+      data[encodedKey] =
+        encodedKey in set1.data ? set1.data[encodedKey] : set2.data[encodedKey];
+    }
+
+    return {type: "map", data};
+  },
+  // End union/2
+  // Deps: []
 };
 
 export default Erlang_Sets;

--- a/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/sets_test.exs
@@ -680,4 +680,68 @@ defmodule Hologram.ExJsConsistency.Erlang.SetsTest do
       end
     end
   end
+
+  describe "union/2" do
+    setup do
+      [
+        empty_set: :sets.new(version: 2),
+        set_123: :sets.from_list([1, 2, 3], version: 2)
+      ]
+    end
+
+    test "returns the union of two sets with some common elements", %{set_123: set_123} do
+      set_234 = :sets.from_list([2, 3, 4], version: 2)
+
+      result = :sets.union(set_123, set_234)
+      expected = :sets.from_list([1, 2, 3, 4], version: 2)
+
+      assert result == expected
+    end
+
+    test "returns the combined set if sets have no common elements" do
+      set_12 = :sets.from_list([1, 2], version: 2)
+      set_3 = :sets.from_list([3], version: 2)
+
+      assert :sets.union(set_12, set_3) == :sets.from_list([1, 2, 3], version: 2)
+    end
+
+    test "returns an empty set if both sets are empty", %{empty_set: empty_set} do
+      assert :sets.union(empty_set, empty_set) == empty_set
+    end
+
+    test "returns the second set if first set is empty", %{empty_set: empty_set, set_123: set_123} do
+      assert :sets.union(empty_set, set_123) == set_123
+    end
+
+    test "returns the first set if second set is empty", %{empty_set: empty_set, set_123: set_123} do
+      assert :sets.union(set_123, empty_set) == set_123
+    end
+
+    test "returns the same set if sets are identical", %{set_123: set_123} do
+      assert :sets.union(set_123, set_123) == set_123
+    end
+
+    test "uses strict matching (integer vs float)" do
+      set_int = :sets.from_list([1], version: 2)
+      set_float = :sets.from_list([1.0], version: 2)
+
+      assert :sets.union(set_int, set_float) == :sets.from_list([1, 1.0], version: 2)
+    end
+
+    test "raises FunctionClauseError if the first argument is not a set", %{set_123: set_123} do
+      expected_msg = build_function_clause_error_msg(":sets.size/1", [:abc])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :sets.union(:abc, set_123)
+      end
+    end
+
+    test "raises FunctionClauseError if the second argument is not a set", %{set_123: set_123} do
+      expected_msg = build_function_clause_error_msg(":sets.size/1", [:abc])
+
+      assert_error FunctionClauseError, expected_msg, fn ->
+        :sets.union(set_123, :abc)
+      end
+    end
+  end
 end

--- a/test/javascript/erlang/sets_test.mjs
+++ b/test/javascript/erlang/sets_test.mjs
@@ -1041,4 +1041,84 @@ describe("Erlang_Sets", () => {
       );
     });
   });
+
+  describe("union/2", () => {
+    const union_2 = Erlang_Sets["union/2"];
+    const from_list_2 = Erlang_Sets["from_list/2"];
+
+    it("returns the union of two sets with some common elements", () => {
+      const set234 = from_list_2(
+        Type.list([integer2, integer3, Type.integer(4)]),
+        opts,
+      );
+
+      const result = union_2(set123, set234);
+
+      const expected = from_list_2(
+        Type.list([integer1, integer2, integer3, Type.integer(4)]),
+        opts,
+      );
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("returns the combined set if sets have no common elements", () => {
+      const set12 = from_list_2(Type.list([integer1, integer2]), opts);
+      const set3 = from_list_2(Type.list([integer3]), opts);
+
+      const result = union_2(set12, set3);
+
+      assert.deepStrictEqual(result, set123);
+    });
+
+    it("returns an empty set if both sets are empty", () => {
+      const result = union_2(emptySet, emptySet);
+
+      assert.deepStrictEqual(result, emptySet);
+    });
+
+    it("returns the second set if first set is empty", () => {
+      const result = union_2(emptySet, set123);
+
+      assert.deepStrictEqual(result, set123);
+    });
+
+    it("returns the first set if second set is empty", () => {
+      const result = union_2(set123, emptySet);
+
+      assert.deepStrictEqual(result, set123);
+    });
+
+    it("returns the same set if sets are identical", () => {
+      const result = union_2(set123, set123);
+
+      assert.deepStrictEqual(result, set123);
+    });
+
+    it("uses strict matching (integer vs float)", () => {
+      const setInt = from_list_2(Type.list([integer1]), opts);
+      const setFloat = from_list_2(Type.list([float1]), opts);
+
+      const result = union_2(setInt, setFloat);
+      const expected = from_list_2(Type.list([integer1, float1]), opts);
+
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it("raises FunctionClauseError if the first argument is not a set", () => {
+      assertBoxedError(
+        () => union_2(atomAbc, set123),
+        "FunctionClauseError",
+        Interpreter.buildFunctionClauseErrorMsg(":sets.size/1", [atomAbc]),
+      );
+    });
+
+    it("raises FunctionClauseError if the second argument is not a set", () => {
+      assertBoxedError(
+        () => union_2(set123, atomAbc),
+        "FunctionClauseError",
+        Interpreter.buildFunctionClauseErrorMsg(":sets.size/1", [atomAbc]),
+      );
+    });
+  });
 });


### PR DESCRIPTION
Closes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added union/2 operation for combining two sets. Merges sets while maintaining element uniqueness and enforcing type consistency (integer vs float).

* **Tests**
  * Extended test coverage for union/2 with scenarios including overlapping elements, disjoint sets, empty sets, identical sets, type strictness, and error handling for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->