### PR TITLE
Fix inconsistent behaviour of JS port of :lists.any/2

### DIFF
--- a/assets/js/erlang/lists.mjs
+++ b/assets/js/erlang/lists.mjs
@@ -46,7 +46,7 @@ const Erlang_Lists = {
   "any/2": (fun, list) => {
     if (!Type.isAnonymousFunction(fun) || fun.arity !== 1) {
       Interpreter.raiseFunctionClauseError(
-        Interpreter.buildFunctionClauseErrorMsg(":lists.any/2", []),
+        Interpreter.buildFunctionClauseErrorMsg(":lists.any/2", [fun, list]),
       );
     }
 
@@ -54,17 +54,25 @@ const Erlang_Lists = {
       Interpreter.raiseCaseClauseError(list);
     }
 
-    if (!Type.isProperList(list)) {
-      Interpreter.raiseFunctionClauseError(
-        Interpreter.buildFunctionClauseErrorMsg(":lists.any/2", [list]),
-      );
-    }
+    const properLength = list.isProper
+      ? list.data.length
+      : list.data.length - 1;
 
-    for (let i = 0; i < list.data.length; i++) {
+    for (let i = 0; i < properLength; i++) {
       const res = Interpreter.callAnonymousFunction(fun, [list.data[i]]);
+
       if (Type.isTrue(res)) {
         return Type.boolean(true);
       }
+    }
+
+    if (!list.isProper) {
+      Interpreter.raiseFunctionClauseError(
+        Interpreter.buildFunctionClauseErrorMsg(":lists.any_1/2", [
+          fun,
+          list.data.at(-1),
+        ]),
+      );
     }
 
     return Type.boolean(false);

--- a/test/elixir/hologram/ex_js_consistency/erlang/lists_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/lists_test.exs
@@ -88,6 +88,12 @@ defmodule Hologram.ExJsConsistency.Erlang.ListsTest do
       assert :lists.any(&(&1 > 2), []) == false
     end
 
+    test "returns true for an improper list if the function returns true before reaching the improper tail" do
+      fun = fn _elem -> true end
+
+      assert :lists.any(fun, [1, 2 | 3])
+    end
+
     test "raises FunctionClauseError if the first arg is not an anonymous function" do
       expected_msg = build_function_clause_error_msg(":lists.any/2", [:not_function, [1, 2, 3]])
 

--- a/test/javascript/erlang/lists_test.mjs
+++ b/test/javascript/erlang/lists_test.mjs
@@ -429,15 +429,40 @@ describe("Erlang_Lists", () => {
       assertBoxedFalse(result);
     });
 
+    it("returns true for an improper list if the function returns true before reaching the improper tail", () => {
+      const list = Type.improperList([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const fun = Type.anonymousFunction(
+        1,
+        [
+          {
+            params: (_context) => [Type.matchPlaceholder()],
+            guards: [],
+            body: (_context) => {
+              return Type.boolean(true);
+            },
+          },
+        ],
+        contextFixture(),
+      );
+
+      const result = any(fun, list);
+
+      assertBoxedTrue(result);
+    });
+
     it("raises FunctionClauseError if the first arg is not an anonymous function", () => {
       assertBoxedError(
         () => any(Type.atom("abc"), properList),
         "FunctionClauseError",
-        Interpreter.buildFunctionClauseErrorMsg(
-          ":lists.any/2",
+        Interpreter.buildFunctionClauseErrorMsg(":lists.any/2", [
           Type.atom("abc"),
           properList,
-        ),
+        ]),
       );
     });
 
@@ -462,11 +487,10 @@ describe("Erlang_Lists", () => {
       assertBoxedError(
         () => any(funArity2, properList),
         "FunctionClauseError",
-        Interpreter.buildFunctionClauseErrorMsg(
-          ":lists.any/2",
+        Interpreter.buildFunctionClauseErrorMsg(":lists.any/2", [
           anonymousCompareFn,
           properList,
-        ),
+        ]),
       );
     });
 
@@ -510,7 +534,10 @@ describe("Erlang_Lists", () => {
       assertBoxedError(
         () => any(fun, improperList),
         "FunctionClauseError",
-        Interpreter.buildFunctionClauseErrorMsg(":lists.any/2", [improperList]),
+        Interpreter.buildFunctionClauseErrorMsg(":lists.any_1/2", [
+          fun,
+          Type.integer(3),
+        ]),
       );
     });
   });


### PR DESCRIPTION
Closes #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the any/2 function for improper lists, ensuring proper validation and clearer error messages when incorrect function arguments are provided.

* **Tests**
  * Added test coverage for improper list behavior to ensure the any/2 function handles edge cases correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->