### PR TITLE
Fix inconsistent behaviour of JS port of :lists.all/2

### DIFF
--- a/assets/js/erlang/lists.mjs
+++ b/assets/js/erlang/lists.mjs
@@ -20,21 +20,25 @@ const Erlang_Lists = {
       Interpreter.raiseCaseClauseError(list);
     }
 
-    if (!Type.isProperList(list)) {
+    const properLength = list.isProper
+      ? list.data.length
+      : list.data.length - 1;
+
+    for (let i = 0; i < properLength; i++) {
+      const res = Interpreter.callAnonymousFunction(fun, [list.data[i]]);
+
+      if (!Type.isTrue(res)) {
+        return Type.boolean(false);
+      }
+    }
+
+    if (!list.isProper) {
       Interpreter.raiseFunctionClauseError(
         Interpreter.buildFunctionClauseErrorMsg(":lists.all_1/2", [
           fun,
           list.data.at(-1),
         ]),
       );
-    }
-
-    for (let i = 0; i < list.data.length; i++) {
-      const res = Interpreter.callAnonymousFunction(fun, [list.data[i]]);
-
-      if (!Type.isTrue(res)) {
-        return Type.boolean(false);
-      }
     }
 
     return Type.boolean(true);

--- a/test/elixir/hologram/ex_js_consistency/erlang/lists_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/lists_test.exs
@@ -30,6 +30,10 @@ defmodule Hologram.ExJsConsistency.Erlang.ListsTest do
       assert :lists.all(fn elem -> elem > 1 end, [])
     end
 
+    test "returns false for an improper list if the function returns false before reaching the improper tail" do
+      assert :lists.all(fn _elem -> false end, [1, 2 | 3]) == false
+    end
+
     test "raises FunctionClauseError if the first arg is not an anonymous function" do
       expected_msg = build_function_clause_error_msg(":lists.all/2", [:not_function, [1, 2, 3]])
 

--- a/test/javascript/erlang/lists_test.mjs
+++ b/test/javascript/erlang/lists_test.mjs
@@ -213,6 +213,32 @@ describe("Erlang_Lists", () => {
       assertBoxedTrue(result);
     });
 
+    it("returns false for an improper list if the function returns false before reaching the improper tail", () => {
+      const list = Type.improperList([
+        Type.integer(1),
+        Type.integer(2),
+        Type.integer(3),
+      ]);
+
+      const fun = Type.anonymousFunction(
+        1,
+        [
+          {
+            params: (_context) => [Type.matchPlaceholder()],
+            guards: [],
+            body: (_context) => {
+              return Type.boolean(false);
+            },
+          },
+        ],
+        contextFixture(),
+      );
+
+      const result = all(fun, list);
+
+      assertBoxedFalse(result);
+    });
+
     it("raises FunctionClauseError if the first arg is not an anonymous function", () => {
       assertBoxedError(
         () => all(Type.atom("not_function"), properList),


### PR DESCRIPTION
Closes #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list operation behavior to correctly handle improper lists, ensuring early termination occurs when conditions are met before encountering the improper tail.

* **Tests**
  * Added comprehensive test coverage for list operations with improper list structures to verify correct evaluation and early termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->