### PR TITLE
Skip Hologram recompilation in language server build environments

### DIFF
--- a/lib/mix/tasks/compile/hologram.ex
+++ b/lib/mix/tasks/compile/hologram.ex
@@ -14,12 +14,14 @@ defmodule Mix.Tasks.Compile.Hologram do
   alias Hologram.Compiler.CallGraph
   alias Hologram.Reflection
 
+  @ls_build_dirs [".elixir_ls", ".elixir-tools", ".expert", ".lexical"]
+
   @impl Mix.Task.Compiler
   # If the options are strings, it means that the task was executed directly by the Elixir compiler.
   def run([hd | _tail]) when is_binary(hd) do
     opts = build_default_opts()
 
-    if elixir_ls_build?(opts) do
+    if language_server_build?(opts) do
       :ok
     else
       run(opts)
@@ -168,8 +170,9 @@ defmodule Mix.Tasks.Compile.Hologram do
     :ok
   end
 
-  defp elixir_ls_build?(opts) do
-    String.contains?(opts[:build_dir], "/.elixir_ls/")
+  defp language_server_build?(opts) do
+    path_components = Path.split(opts[:build_dir])
+    Enum.any?(@ls_build_dirs, fn dir -> dir in path_components end)
   end
 
   defp maybe_adjust_formatter_bin_path(opts) do


### PR DESCRIPTION
Fixes #727 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build now correctly skips unnecessary recompilation for a broader set of language-server environments by expanding detection of editor/IDE tool directories.
  * Resulting improvements: faster build/startup times and lower CPU usage when using language-server workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->