### PR TITLE
Stop the CallGraph processes after compilation

### DIFF
--- a/lib/hologram/commons/plt.ex
+++ b/lib/hologram/commons/plt.ex
@@ -18,14 +18,14 @@ defmodule Hologram.Commons.PLT do
   @doc """
   Returns a clone of the PLT.
   """
-  @spec clone(PLT.t()) :: PLT.t()
-  def clone(plt) do
+  @spec clone(PLT.t(), T.opts()) :: PLT.t()
+  def clone(plt, opts \\ []) do
     items =
       plt
       |> get_all()
       |> Map.to_list()
 
-    put(start(), items)
+    put(start(opts), items)
   end
 
   @doc """
@@ -180,9 +180,26 @@ defmodule Hologram.Commons.PLT do
   """
   @spec start(T.opts()) :: PLT.t()
   def start(opts \\ []) do
-    genserver_opts = Keyword.delete(opts, :table_name)
+    genserver_opts =
+      opts
+      |> Keyword.delete(:table_name)
+      |> Keyword.delete(:supervisor)
 
-    {:ok, pid} = GenServer.start_link(PLT, opts[:table_name], genserver_opts)
+    {:ok, pid} =
+      case opts[:supervisor] do
+        nil ->
+          GenServer.start_link(PLT, opts[:table_name], genserver_opts)
+
+        sup ->
+          child_spec = %{
+            id: :plt,
+            restart: :temporary,
+            start: {GenServer, :start_link, [PLT, opts[:table_name], genserver_opts]}
+          }
+
+          DynamicSupervisor.start_child(sup, child_spec)
+      end
+
     table_ref = GenServer.call(pid, :get_table_ref)
 
     plt = %PLT{pid: pid, table_ref: table_ref, table_name: opts[:table_name]}

--- a/lib/hologram/compiler.ex
+++ b/lib/hologram/compiler.ex
@@ -10,6 +10,7 @@ defmodule Hologram.Compiler do
   alias Hologram.Commons.Types, as: T
   alias Hologram.Compiler.CallGraph
   alias Hologram.Compiler.Context
+  alias Hologram.Compiler.Digraph
   alias Hologram.Compiler.Encoder
   alias Hologram.Compiler.IR
   alias Hologram.Reflection
@@ -102,11 +103,11 @@ defmodule Hologram.Compiler do
 
   Benchmark: https://github.com/bartblast/hologram/blob/master/benchmarks/compiler/build_ir_plt_1/README.md
   """
-  @spec build_ir_plt :: PLT.t()
+  @spec build_ir_plt(T.opts()) :: PLT.t()
   # credo:disable-for-lines:26 Credo.Check.Refactor.Nesting
   # The above Credo check is disabled because the function is optimised this way
-  def build_ir_plt do
-    ir_plt = PLT.start()
+  def build_ir_plt(opts \\ []) do
+    ir_plt = PLT.start(opts)
 
     modules = Reflection.list_elixir_modules()
 
@@ -136,9 +137,9 @@ defmodule Hologram.Compiler do
 
   Benchmarks: https://github.com/bartblast/hologram/blob/master/benchmarks/compiler/build_module_digest_plt!_1/README.md
   """
-  @spec build_module_digest_plt! :: PLT.t()
-  def build_module_digest_plt! do
-    module_digest_plt = PLT.start()
+  @spec build_module_digest_plt!(T.opts()) :: PLT.t()
+  def build_module_digest_plt!(opts \\ []) do
+    module_digest_plt = PLT.start(opts)
 
     Reflection.list_elixir_modules()
     |> TaskUtils.async_many(&rebuild_module_digest_plt_entry!(&1, module_digest_plt))
@@ -160,7 +161,10 @@ defmodule Hologram.Compiler do
         [{page_module, digest} | acc]
       end)
 
-    page_digest_plt = PLT.start(items: page_digest_plt_items)
+    page_digest_plt =
+      opts
+      |> Keyword.put(:items, page_digest_plt_items)
+      |> PLT.start()
 
     page_digest_plt_dump_path =
       Path.join([opts[:build_dir], Reflection.page_digest_plt_dump_file_name()])
@@ -565,9 +569,9 @@ defmodule Hologram.Compiler do
 
   Benchmarks: https://github.com/bartblast/hologram/blob/master/benchmarks/compiler/maybe_load_call_graph_1/README.md
   """
-  @spec maybe_load_call_graph(T.file_path()) :: {CallGraph.t(), String.t()}
-  def maybe_load_call_graph(build_dir) do
-    call_graph = CallGraph.start()
+  @spec maybe_load_call_graph(T.file_path(), T.opts()) :: {CallGraph.t(), String.t()}
+  def maybe_load_call_graph(build_dir, opts \\ []) do
+    call_graph = CallGraph.start(Digraph.new(), opts)
     call_graph_dump_path = Path.join(build_dir, Reflection.call_graph_dump_file_name())
     CallGraph.maybe_load(call_graph, call_graph_dump_path)
 
@@ -593,9 +597,9 @@ defmodule Hologram.Compiler do
 
   Benchmarks: https://github.com/bartblast/hologram/blob/master/benchmarks/compiler/maybe_load_module_digest_plt_1/README.md
   """
-  @spec maybe_load_module_digest_plt(T.file_path()) :: {PLT.t(), String.t()}
-  def maybe_load_module_digest_plt(build_dir) do
-    module_digest_plt = PLT.start()
+  @spec maybe_load_module_digest_plt(T.file_path(), T.opts()) :: {PLT.t(), String.t()}
+  def maybe_load_module_digest_plt(build_dir, opts \\ []) do
+    module_digest_plt = PLT.start(opts)
 
     module_digest_plt_dump_path =
       Path.join(build_dir, Reflection.module_digest_plt_dump_file_name())

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -4,6 +4,7 @@ defmodule Hologram.Compiler.CallGraph do
   alias Hologram.Commons.PLT
   alias Hologram.Commons.SerializationUtils
   alias Hologram.Commons.TaskUtils
+  alias Hologram.Commons.Types, as: T
   alias Hologram.Compiler.CallGraph
   alias Hologram.Compiler.Digraph
   alias Hologram.Compiler.IR
@@ -515,10 +516,10 @@ defmodule Hologram.Compiler.CallGraph do
 
   Benchmark: https://github.com/bartblast/hologram/blob/master/benchmarks/compiler/call_graph/clone_1/README.md
   """
-  @spec clone(t) :: t
-  def clone(call_graph) do
+  @spec clone(t, T.opts()) :: t
+  def clone(call_graph, opts \\ []) do
     graph = get_graph(call_graph)
-    start(graph)
+    start(graph, opts)
   end
 
   @doc """
@@ -908,9 +909,23 @@ defmodule Hologram.Compiler.CallGraph do
   @doc """
   Starts a new call graph agent with (optional) initial graph.
   """
-  @spec start(Digraph.t()) :: t
-  def start(graph \\ Digraph.new()) do
-    {:ok, pid} = Agent.start_link(fn -> graph end)
+  @spec start(Digraph.t(), T.opts()) :: t
+  def start(graph \\ Digraph.new(), opts \\ []) do
+    {:ok, pid} =
+      case opts[:supervisor] do
+        nil ->
+          Agent.start_link(fn -> graph end)
+
+        sup ->
+          child_spec = %{
+            id: :call_graph,
+            restart: :temporary,
+            start: {Agent, :start_link, [fn -> graph end]}
+          }
+
+          DynamicSupervisor.start_child(sup, child_spec)
+      end
+
     %CallGraph{pid: pid}
   end
 

--- a/lib/mix/tasks/compile/hologram.ex
+++ b/lib/mix/tasks/compile/hologram.ex
@@ -79,103 +79,110 @@ defmodule Mix.Tasks.Compile.Hologram do
   end
 
   defp compile(opts) do
-    Logger.info("Hologram: compiler started")
+    {:ok, sup} = DynamicSupervisor.start_link([])
 
-    assets_dir = opts[:assets_dir]
-    build_dir = opts[:build_dir]
+    try do
+      Logger.info("Hologram: compiler started")
 
-    File.mkdir_p!(build_dir)
-    File.mkdir_p!(opts[:static_dir])
-    File.mkdir_p!(opts[:tmp_dir])
+      assets_dir = opts[:assets_dir]
+      build_dir = opts[:build_dir]
 
-    Compiler.maybe_install_js_deps(assets_dir, build_dir)
+      File.mkdir_p!(build_dir)
+      File.mkdir_p!(opts[:static_dir])
+      File.mkdir_p!(opts[:tmp_dir])
 
-    opts = maybe_adjust_formatter_bin_path(opts)
+      Compiler.maybe_install_js_deps(assets_dir, build_dir)
 
-    {old_module_digest_plt, module_digest_plt_dump_path} =
-      Compiler.maybe_load_module_digest_plt(build_dir)
+      opts = maybe_adjust_formatter_bin_path(opts)
 
-    new_module_digest_plt = Compiler.build_module_digest_plt!()
+      {old_module_digest_plt, module_digest_plt_dump_path} =
+        Compiler.maybe_load_module_digest_plt(build_dir, supervisor: sup)
 
-    module_digests_diff =
-      Compiler.diff_module_digest_plts(old_module_digest_plt, new_module_digest_plt)
+      new_module_digest_plt = Compiler.build_module_digest_plt!(supervisor: sup)
 
-    # Building IR PLT from scratch is faster that dumping it to a file,
-    # and then loading and patching it (benchmarked on an app with 1628 modules):
-    # build: ~310 ms
-    # dump: ~350 ms
-    # load: ~465 ms
-    # patch: not benchmarked
-    ir_plt = Compiler.build_ir_plt()
+      module_digests_diff =
+        Compiler.diff_module_digest_plts(old_module_digest_plt, new_module_digest_plt)
 
-    {call_graph, call_graph_dump_path} = Compiler.maybe_load_call_graph(build_dir)
+      # Building IR PLT from scratch is faster that dumping it to a file,
+      # and then loading and patching it (benchmarked on an app with 1628 modules):
+      # build: ~310 ms
+      # dump: ~350 ms
+      # load: ~465 ms
+      # patch: not benchmarked
+      ir_plt = Compiler.build_ir_plt(supervisor: sup)
 
-    call_graph
-    |> CallGraph.patch(ir_plt, module_digests_diff)
-    |> CallGraph.add_non_discoverable_edges()
+      {call_graph, call_graph_dump_path} =
+        Compiler.maybe_load_call_graph(build_dir, supervisor: sup)
 
-    # Must be computed before remove_manually_ported_mfas/1 strips the Task.await/1 vertex.
-    async_mfas = CallGraph.list_async_mfas(call_graph)
-
-    call_graph_for_runtime =
       call_graph
-      |> CallGraph.clone()
-      # DEFER: In case the list of manually ported MFAs grows to ~32 vertices,
-      # consider using similar strategy to CallGraph.remove_runtime_mfas!/2
-      # or implement opts param for Digraph.remove_vertices/2 to allow rebuilding the graph.
-      |> CallGraph.remove_manually_ported_mfas()
+      |> CallGraph.patch(ir_plt, module_digests_diff)
+      |> CallGraph.add_non_discoverable_edges()
 
-    runtime_mfas = CallGraph.list_runtime_mfas(call_graph_for_runtime)
+      # Must be computed before remove_manually_ported_mfas/1 strips the Task.await/1 vertex.
+      async_mfas = CallGraph.list_async_mfas(call_graph)
 
-    runtime_entry_file_path =
-      Compiler.create_runtime_entry_file(runtime_mfas, ir_plt, async_mfas, opts)
+      call_graph_for_runtime =
+        call_graph
+        |> CallGraph.clone(supervisor: sup)
+        # DEFER: In case the list of manually ported MFAs grows to ~32 vertices,
+        # consider using similar strategy to CallGraph.remove_runtime_mfas!/2
+        # or implement opts param for Digraph.remove_vertices/2 to allow rebuilding the graph.
+        |> CallGraph.remove_manually_ported_mfas()
 
-    page_modules = Reflection.list_pages()
+      runtime_mfas = CallGraph.list_runtime_mfas(call_graph_for_runtime)
 
-    Compiler.validate_page_modules(page_modules)
+      runtime_entry_file_path =
+        Compiler.create_runtime_entry_file(runtime_mfas, ir_plt, async_mfas, opts)
 
-    call_graph_for_pages = CallGraph.remove_runtime_mfas!(call_graph_for_runtime, runtime_mfas)
+      page_modules = Reflection.list_pages()
 
-    page_entry_files_info =
-      page_modules
-      |> Compiler.create_page_entry_files(call_graph_for_pages, ir_plt, async_mfas, opts)
-      |> Enum.map(fn {entry_name, entry_file_path} ->
-        {entry_name, entry_file_path, "page"}
-      end)
+      Compiler.validate_page_modules(page_modules)
 
-    page_entry_file_paths =
-      Enum.map(page_entry_files_info, fn {_entry_name, entry_file_path, _bundle_name} ->
-        entry_file_path
-      end)
+      call_graph_for_pages = CallGraph.remove_runtime_mfas!(call_graph_for_runtime, runtime_mfas)
 
-    Compiler.format_files([runtime_entry_file_path | page_entry_file_paths], opts)
+      page_entry_files_info =
+        page_modules
+        |> Compiler.create_page_entry_files(call_graph_for_pages, ir_plt, async_mfas, opts)
+        |> Enum.map(fn {entry_name, entry_file_path} ->
+          {entry_name, entry_file_path, "page"}
+        end)
 
-    entry_files_info = [{"runtime", runtime_entry_file_path, "runtime"} | page_entry_files_info]
+      page_entry_file_paths =
+        Enum.map(page_entry_files_info, fn {_entry_name, entry_file_path, _bundle_name} ->
+          entry_file_path
+        end)
 
-    old_build_static_artifacts =
-      opts[:static_dir]
-      |> File.ls!()
-      |> Enum.map(fn file_name -> Path.join(opts[:static_dir], file_name) end)
+      Compiler.format_files([runtime_entry_file_path | page_entry_file_paths], opts)
 
-    bundles_info = Compiler.bundle(entry_files_info, opts)
+      entry_files_info = [{"runtime", runtime_entry_file_path, "runtime"} | page_entry_files_info]
 
-    new_build_static_artifacts =
-      Enum.reduce(bundles_info, [], fn bundle_info, acc ->
-        [bundle_info.static_bundle_path, bundle_info.static_source_map_path | acc]
-      end)
+      old_build_static_artifacts =
+        opts[:static_dir]
+        |> File.ls!()
+        |> Enum.map(fn file_name -> Path.join(opts[:static_dir], file_name) end)
 
-    {page_digest_plt, page_digest_plt_dump_path} =
-      Compiler.build_page_digest_plt(bundles_info, opts)
+      bundles_info = Compiler.bundle(entry_files_info, opts)
 
-    PLT.dump(page_digest_plt, page_digest_plt_dump_path)
-    CallGraph.dump(call_graph, call_graph_dump_path)
-    PLT.dump(new_module_digest_plt, module_digest_plt_dump_path)
+      new_build_static_artifacts =
+        Enum.reduce(bundles_info, [], fn bundle_info, acc ->
+          [bundle_info.static_bundle_path, bundle_info.static_source_map_path | acc]
+        end)
 
-    Enum.each(old_build_static_artifacts -- new_build_static_artifacts, &File.rm!/1)
+      {page_digest_plt, page_digest_plt_dump_path} =
+        Compiler.build_page_digest_plt(bundles_info, Keyword.put(opts, :supervisor, sup))
 
-    Logger.info("Hologram: compiler finished")
+      PLT.dump(page_digest_plt, page_digest_plt_dump_path)
+      CallGraph.dump(call_graph, call_graph_dump_path)
+      PLT.dump(new_module_digest_plt, module_digest_plt_dump_path)
 
-    :ok
+      Enum.each(old_build_static_artifacts -- new_build_static_artifacts, &File.rm!/1)
+
+      Logger.info("Hologram: compiler finished")
+
+      :ok
+    after
+      DynamicSupervisor.stop(sup)
+    end
   end
 
   defp language_server_build?(opts) do


### PR DESCRIPTION
During Hologram compilation, there are 2 CallGraph processes that get started. These processes are responsible for maintaining the graph of function calls through your system.

Unfortunately, these processes are never cleaned up. This is fine for a standalone compile step, because when mix returns, the processes will be gone with the rest of the VM. However, in a situation like Phoenix Code Reloading, each file save will spawn an additional 2 CallGraph processes. This leads to large amounts of memory being wasted in development as the CallGraph processes are not used after the compiler has finished working.

After the compilation step is complete, the CallGraph module will dump its state to disk in order to persist for the next run. This means that we do not need to keep the previous CallGraph process around for any reason as starting a new one will retrieve the state from the previous run.

Resolves #440 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Compilation now runs in an isolated, supervised subprocess with reliable teardown to reduce resource leaks and improve build stability.
* **Refactor**
  * Internal caches, graphs and related processes can now be started under supervision and cloned with configurable options for more predictable lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->