### PR TITLE
Fix :erlang.list_to_binary/1 handling of nested improper-list iodata

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -1615,6 +1615,8 @@ const Erlang = {
 
         if (Type.isBinary(tail)) {
           chunks.push(tail);
+        } else if (Type.isList(tail)) {
+          collect(tail);
         } else {
           Interpreter.raiseArgumentError(
             Interpreter.buildArgumentErrorMsg(1, "not an iolist term"),

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -3863,6 +3863,13 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
                <<1, 2, 3, 1, 2, 3, 4, 5, 4, 6>>
     end
 
+    test "accepts nested cons-built iodata used by date formatting" do
+      zero_pad = [<<"0">> | <<"1">>]
+      iodata = [<<"2022">> | [45 | [zero_pad | [45 | zero_pad]]]]
+
+      assert :erlang.list_to_binary(iodata) == "2022-01-01"
+    end
+
     test "list with empty sublists" do
       assert :erlang.list_to_binary([[], [], []]) == <<>>
     end

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -6265,6 +6265,31 @@ describe("Erlang", () => {
       );
     });
 
+    it("accepts nested cons-built iodata used by date formatting", () => {
+      const zeroPad = Type.improperList([
+        Type.bitstring("0"),
+        Type.bitstring("1"),
+      ]);
+
+      const result = list_to_binary(
+        Type.improperList([
+          Type.bitstring("2022"),
+          Type.improperList([
+            Type.integer(45),
+            Type.improperList([
+              zeroPad,
+              Type.improperList([Type.integer(45), zeroPad]),
+            ]),
+          ]),
+        ]),
+      );
+
+      assert.deepStrictEqual(
+        result,
+        Bitstring.fromBytes([50, 48, 50, 50, 45, 48, 49, 45, 48, 49]),
+      );
+    });
+
     it("list with empty sublists", () => {
       const result = list_to_binary(
         Type.list([Type.list(), Type.list(), Type.list()]),


### PR DESCRIPTION
Fixes #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `list_to_binary/1` to properly handle deeply nested improper-list iodata structures containing nested lists and mixed data types. The function now correctly processes complex nested list compositions with binaries, integers, and other iodata components, enabling accurate conversion to binary format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->