### PR TITLE
Delegate :erlang.iolist_to_binary/1 to :erlang.list_to_binary/1 and align iodata errors

### DIFF
--- a/assets/js/erlang/erlang.mjs
+++ b/assets/js/erlang/erlang.mjs
@@ -1376,35 +1376,38 @@ const Erlang = {
   // TODO: test
   // Start iolist_to_binary/1
   "iolist_to_binary/1": (ioListOrBinary) => {
-    // TODO: validate arg
-
-    if (Type.isBitstring(ioListOrBinary)) {
+    if (Type.isBinary(ioListOrBinary)) {
       return ioListOrBinary;
     }
 
-    const chunks = Erlang_Lists["flatten/1"](ioListOrBinary).data.map(
-      (term) => {
-        // TODO: validate list item (binary or integer allowed)
+    if (!Type.isList(ioListOrBinary)) {
+      Interpreter.raiseArgumentError(
+        Interpreter.buildArgumentErrorMsg(1, "not an iodata term"),
+      );
+    }
 
-        if (Type.isBitstring(term)) {
-          return term;
-        }
+    try {
+      return Erlang["list_to_binary/1"](ioListOrBinary);
+    } catch (error) {
+      const listToBinaryError = Type.errorStruct(
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not an iolist term"),
+      );
 
-        const segment = Type.bitstringSegment(term, {
-          type: "integer",
-          size: Type.integer(8),
-          unit: 1n,
-          endianness: "big",
-        });
+      if (
+        error instanceof HologramBoxedError &&
+        Interpreter.isStrictlyEqual(error.struct, listToBinaryError)
+      ) {
+        Interpreter.raiseArgumentError(
+          Interpreter.buildArgumentErrorMsg(1, "not an iodata term"),
+        );
+      }
 
-        return Bitstring.fromSegmentWithIntegerValue(segment);
-      },
-    );
-
-    return Bitstring.concat(chunks);
+      throw error;
+    }
   },
   // End iolist_to_binary/1
-  // Deps: [:lists.flatten/1]
+  // Deps: [:erlang.list_to_binary/1]
 
   // Start is_atom/1
   "is_atom/1": (term) => {

--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -55,7 +55,7 @@ defmodule Hologram.Compiler.CallGraph do
     {{:erlang, :fun_info, 2}, {:erlang, :fun_info, 1}},
     {{:erlang, :integer_to_binary, 1}, {:erlang, :integer_to_binary, 2}},
     {{:erlang, :integer_to_list, 1}, {:erlang, :integer_to_list, 2}},
-    {{:erlang, :iolist_to_binary, 1}, {:lists, :flatten, 1}},
+    {{:erlang, :iolist_to_binary, 1}, {:erlang, :list_to_binary, 1}},
     {{:erlang, :is_map_key, 2}, {:maps, :is_key, 2}},
     {{:erlang, :list_to_existing_atom, 1}, {:erlang, :list_to_atom, 1}},
     {{:erlang, :list_to_integer, 1}, {:erlang, :list_to_integer, 2}},

--- a/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/erlang_test.exs
@@ -3565,6 +3565,31 @@ defmodule Hologram.ExJsConsistency.Erlang.ErlangTest do
     end
   end
 
+  describe "iolist_to_binary/1" do
+    test "returns a binary unchanged" do
+      assert :erlang.iolist_to_binary(<<1, 2, 3>>) == <<1, 2, 3>>
+    end
+
+    test "delegates valid list input to list_to_binary/1" do
+      zero_pad = [<<"0">> | <<"1">>]
+      iodata = [<<"2022">> | [45 | [zero_pad | [45 | zero_pad]]]]
+
+      assert :erlang.iolist_to_binary(iodata) == "2022-01-01"
+    end
+
+    test "raises ArgumentError for non-list input" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not an iodata term"),
+                   {:erlang, :iolist_to_binary, [<<1::3>>]}
+    end
+
+    test "remaps invalid iolist errors from list_to_binary/1" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(1, "not an iodata term"),
+                   {:erlang, :iolist_to_binary, [[<<1::3>>]]}
+    end
+  end
+
   describe "is_atom/1" do
     test "atom" do
       assert :erlang.is_atom(:abc) == true

--- a/test/javascript/erlang/erlang_test.mjs
+++ b/test/javascript/erlang/erlang_test.mjs
@@ -5821,6 +5821,75 @@ describe("Erlang", () => {
     });
   });
 
+  describe("iolist_to_binary/1", () => {
+    const iolist_to_binary = Erlang["iolist_to_binary/1"];
+
+    it("returns a binary unchanged", () => {
+      const binary = Bitstring.fromBytes([1, 2, 3]);
+
+      assert.deepStrictEqual(iolist_to_binary(binary), binary);
+    });
+
+    it("converts valid iodata list to binary", () => {
+      const zeroPad = Type.improperList([
+        Type.bitstring("0"),
+        Type.bitstring("1"),
+      ]);
+
+      const result = iolist_to_binary(
+        Type.improperList([
+          Type.bitstring("2022"),
+          Type.improperList([
+            Type.integer(45),
+            Type.improperList([
+              zeroPad,
+              Type.improperList([Type.integer(45), zeroPad]),
+            ]),
+          ]),
+        ]),
+      );
+
+      assert.deepStrictEqual(
+        result,
+        Bitstring.fromBytes([50, 48, 50, 50, 45, 48, 49, 45, 48, 49]),
+      );
+    });
+
+    it("raises ArgumentError for non-list input", () => {
+      assertBoxedError(
+        () =>
+          iolist_to_binary(
+            Type.bitstring([
+              Type.bitstringSegment(Type.integer(1), {
+                type: "integer",
+                size: Type.integer(3),
+              }),
+            ]),
+          ),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not an iodata term"),
+      );
+    });
+
+    it("remaps invalid iolist errors from list_to_binary/1", () => {
+      assertBoxedError(
+        () =>
+          iolist_to_binary(
+            Type.list([
+              Type.bitstring([
+                Type.bitstringSegment(Type.integer(1), {
+                  type: "integer",
+                  size: Type.integer(3),
+                }),
+              ]),
+            ]),
+          ),
+        "ArgumentError",
+        Interpreter.buildArgumentErrorMsg(1, "not an iodata term"),
+      );
+    });
+  });
+
   describe("is_atom/1", () => {
     const is_atom = Erlang["is_atom/1"];
 


### PR DESCRIPTION
Fixes #752

## Dependencies

- [x] #753 

## Fix

The fix identified is:

1. Change `:erlang.iolist_to_binary/1` to accept only binaries as direct passthrough.
2. For list input, delegate to `erlang.list_to_binary/1` instead of reimplementing conversion.
3. For obvious non-list, non-binary input, raise ArgumentError with `not an iodata term`
4. If delegated `erlang:list_to_binary/1` raises the specific boxed `ArgumentError` with `not an iolist term` remap that one error to `not an iodata term`.

Why that fix is correct:

- `:erlang.list_to_binary/1` already owns the real recursive iolist validation/conversion logic.
- `:erlang.iolist_to_binary/1` should differ mainly in accepted direct input and error wording.
- Delegating removes duplicated logic and keeps both functions aligned while still preserving their distinct OTP contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter input validation for binary conversion: invalid inputs now raise a consistent ArgumentError.
  * Preserves already-binary inputs and improves handling of nested/improper list shapes, including nested tails.

* **Tests**
  * Added comprehensive tests covering identity behavior, nested/improper list conversions, validation failures, and consistent error remapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->