### PR TITLE
Add `action/3`, `command/3` and `init/2` as optional callbacks

### DIFF
--- a/lib/hologram/component.ex
+++ b/lib/hologram/component.ex
@@ -12,7 +12,7 @@ defmodule Hologram.Component do
 
     @type t :: %__MODULE__{
             delay: non_neg_integer,
-            name: :atom,
+            name: atom(),
             params: %{atom => any},
             target: String.t() | nil
           }

--- a/lib/hologram/component.ex
+++ b/lib/hologram/component.ex
@@ -38,6 +38,13 @@ defmodule Hologram.Component do
   @callback init(%{atom => any}, Component.t(), Server.t()) ::
               {Component.t(), Server.t()} | Component.t() | Server.t()
 
+  # The following callbacks are implemented so that users may use
+  # `@impl Hologram.Component` in their component modules.
+  @callback init(map, Component.t()) :: Component.t()
+  @callback action(atom, map, Component.t()) :: Component.t()
+  @callback command(atom, map, Server.t()) :: Server.t()
+  @optional_callbacks [init: 2, action: 3, command: 3]
+
   @doc """
   Returns a template in the form of an anonymous function that given variable bindings returns a DOM.
   """

--- a/lib/hologram/component.ex
+++ b/lib/hologram/component.ex
@@ -38,11 +38,21 @@ defmodule Hologram.Component do
   @callback init(%{atom => any}, Component.t(), Server.t()) ::
               {Component.t(), Server.t()} | Component.t() | Server.t()
 
-  # The following callbacks are implemented so that users may use
-  # `@impl Hologram.Component` in their component modules.
+  @doc """
+  Called when the component starts its lifecycle directly on the client.
+  """
   @callback init(%{atom => any}, Component.t()) :: Component.t()
+
+  @doc """
+  Client side operations, typically executed in response to user interactions.
+  """
   @callback action(atom, %{atom => any}, Component.t()) :: Component.t()
+
+  @doc """
+  Run server-side operations.
+  """
   @callback command(atom, %{atom => any}, Server.t()) :: Server.t()
+
   @optional_callbacks [init: 2, action: 3, command: 3]
 
   @doc """

--- a/lib/hologram/component.ex
+++ b/lib/hologram/component.ex
@@ -40,9 +40,9 @@ defmodule Hologram.Component do
 
   # The following callbacks are implemented so that users may use
   # `@impl Hologram.Component` in their component modules.
-  @callback init(map, Component.t()) :: Component.t()
-  @callback action(atom, map, Component.t()) :: Component.t()
-  @callback command(atom, map, Server.t()) :: Server.t()
+  @callback init(%{atom => any}, Component.t()) :: Component.t()
+  @callback action(atom, %{atom => any}, Component.t()) :: Component.t()
+  @callback command(atom, %{atom => any}, Server.t()) :: Server.t()
   @optional_callbacks [init: 2, action: 3, command: 3]
 
   @doc """

--- a/lib/hologram/page.ex
+++ b/lib/hologram/page.ex
@@ -18,6 +18,12 @@ defmodule Hologram.Page do
   """
   @callback template() :: (map -> list)
 
+  # The following callbacks are implemented so that users may use
+  # `@impl Hologram.Page` in their page modules.
+  @callback action(atom, map, Component.t()) :: Component.t()
+  @callback command(atom, map, Server.t()) :: Server.t()
+  @optional_callbacks [action: 3, command: 3]
+
   defmacro __using__(_opts) do
     template_path = Component.colocated_template_path(__CALLER__.file)
 

--- a/lib/hologram/page.ex
+++ b/lib/hologram/page.ex
@@ -18,10 +18,16 @@ defmodule Hologram.Page do
   """
   @callback template() :: (map -> list)
 
-  # The following callbacks are implemented so that users may use
-  # `@impl Hologram.Page` in their page modules.
+  @doc """
+  Called when the component starts its lifecycle directly on the client.
+  """
   @callback action(atom, map, Component.t()) :: Component.t()
+
+  @doc """
+  Run server-side operations.
+  """
   @callback command(atom, map, Server.t()) :: Server.t()
+
   @optional_callbacks [action: 3, command: 3]
 
   defmacro __using__(_opts) do

--- a/test/elixir/hologram/component_test.exs
+++ b/test/elixir/hologram/component_test.exs
@@ -1,6 +1,7 @@
 defmodule Hologram.ComponentTest do
   use Hologram.Test.BasicCase, async: true
   import Hologram.Component
+  import ExUnit.CaptureIO
 
   alias Hologram.Component
   alias Hologram.Component.Action
@@ -323,6 +324,77 @@ defmodule Hologram.ComponentTest do
              ] = result
 
       assert normalize_newlines(text) == "Module3 template\n"
+    end
+  end
+
+  describe "optional callbacks" do
+    test "raises impl warning when impl not given for init" do
+      warning =
+        capture_io(:stderr, fn ->
+          Code.compile_string("""
+          defmodule TestComponentInitOptionalCallbacks do
+            use Hologram.Component
+
+            def init(_params, component) do
+              component
+            end
+
+            @impl Hologram.Component
+            def template do
+              ~HOLO""
+            end
+          end
+          """)
+        end)
+
+      assert warning =~ "warning:"
+      assert warning =~ "module attribute @impl was not set for function init/2"
+    end
+
+    test "raises impl warning when impl not given for action" do
+      warning =
+        capture_io(:stderr, fn ->
+          Code.compile_string("""
+          defmodule TestComponentActionOptionalCallbacks do
+            use Hologram.Component
+
+            @impl Hologram.Component
+            def template do
+              ~HOLO""
+            end
+
+            def action(:fire_missiles, _params, component) do
+              component
+            end
+          end
+          """)
+        end)
+
+      assert warning =~ "warning:"
+      assert warning =~ "module attribute @impl was not set for function action/3"
+    end
+
+    test "raises impl warning when impl not given for command" do
+      warning =
+        capture_io(:stderr, fn ->
+          Code.compile_string("""
+          defmodule TestPageCommandOptionalCallbacks do
+            use Hologram.Component
+
+            @impl Hologram.Component
+            def template do
+              ~HOLO""
+            end
+
+            def command(:fire_missiles, _params, server) do
+              server
+            end
+          end
+          """)
+        end)
+
+      assert warning =~ "warning:"
+      assert warning =~ "module attribute @impl was not set for function command/3"
     end
   end
 end

--- a/test/elixir/hologram/page_test.exs
+++ b/test/elixir/hologram/page_test.exs
@@ -1,6 +1,7 @@
 defmodule Hologram.PageTest do
   use Hologram.Test.BasicCase, async: true
   import Hologram.Page
+  import ExUnit.CaptureIO
 
   alias Hologram.Component
   alias Hologram.Server
@@ -147,6 +148,54 @@ defmodule Hologram.PageTest do
              ] = result
 
       assert normalize_newlines(text) == "Module5 template\n"
+    end
+  end
+
+  describe "optional callbacks" do
+    test "raises impl warning when impl not given for action" do
+      warning =
+        capture_io(:stderr, fn ->
+          Code.compile_string("""
+          defmodule TestPageActionOptionalCallbacks do
+            use Hologram.Page
+
+            @impl Hologram.Page
+            def template do
+              ~HOLO""
+            end
+
+            def action(:fire_missiles, _params, component) do
+              component
+            end
+          end
+          """)
+        end)
+
+      assert warning =~ "warning:"
+      assert warning =~ "module attribute @impl was not set for function action/3"
+    end
+
+    test "raises impl warning when impl not given for command" do
+      warning =
+        capture_io(:stderr, fn ->
+          Code.compile_string("""
+          defmodule TestPageCommand do
+            use Hologram.Page
+
+            @impl Hologram.Page
+            def template do
+              ~HOLO""
+            end
+
+            def command(:siphon_money, _params, server) do
+              server
+            end
+          end
+          """)
+        end)
+
+      assert warning =~ "warning:"
+      assert warning =~ "module attribute @impl was not set for function command/3"
     end
   end
 end

--- a/test/elixir/support/fixtures/compiler/call_graph/module_38.ex
+++ b/test/elixir/support/fixtures/compiler/call_graph/module_38.ex
@@ -1,0 +1,21 @@
+# credo:disable-for-this-file Credo.Check.Readability.Specs
+defmodule Hologram.Test.Fixtures.Compiler.CallGraph.Module38 do
+  use Hologram.Component
+
+  @impl Component
+  def init(_props, component) do
+    component
+  end
+
+  @impl Component
+  def template do
+    ~HOLO"""
+    Module38 template
+    """
+  end
+
+  @impl Component
+  def action(_action, _params, component) do
+    component
+  end
+end

--- a/test/elixir/support/fixtures/compiler/call_graph/module_43.ex
+++ b/test/elixir/support/fixtures/compiler/call_graph/module_43.ex
@@ -1,0 +1,16 @@
+# credo:disable-for-this-file Credo.Check.Readability.Specs
+defmodule Hologram.Test.Fixtures.Compiler.CallGraph.Module43 do
+  use Hologram.Component
+
+  @impl Component
+  def template do
+    ~HOLO"""
+    Module43 template
+    """
+  end
+
+  @impl Component
+  def command(:command_43a, _params, server) do
+    server
+  end
+end

--- a/test/elixir/support/fixtures/compiler/module_10.ex
+++ b/test/elixir/support/fixtures/compiler/module_10.ex
@@ -12,5 +12,5 @@ defmodule Hologram.Test.Fixtures.Compiler.Module10 do
     fun_10a(params, component)
   end
 
-  def fun_10a(params, state), do: {params, state}
+  def fun_10a(_params, state), do: state
 end

--- a/test/elixir/support/fixtures/compiler/module_18.ex
+++ b/test/elixir/support/fixtures/compiler/module_18.ex
@@ -6,5 +6,5 @@ defmodule Hologram.Test.Fixtures.Compiler.Module18 do
 
   js_import :export_1a, from: @js_fixture_path, as: :alias_1a
 
-  def my_fun, do: :ok
+  def my_fun, do: %Hologram.Component{}
 end

--- a/test/elixir/support/fixtures/compiler/module_20.ex
+++ b/test/elixir/support/fixtures/compiler/module_20.ex
@@ -7,5 +7,5 @@ defmodule Hologram.Test.Fixtures.Compiler.Module20 do
   js_import :export_1a, from: @js_fixture_path, as: :alias_1a
   js_import :export_1b, from: @js_fixture_path, as: :alias_1b
 
-  def my_fun, do: :ok
+  def my_fun, do: %Hologram.Component{}
 end

--- a/test/elixir/support/fixtures/compiler/module_23.ex
+++ b/test/elixir/support/fixtures/compiler/module_23.ex
@@ -16,6 +16,8 @@ defmodule Hologram.Test.Fixtures.Compiler.Module23 do
   end
 
   def action(:action_23a, _params, _component) do
-    {Module18.my_fun(), Module22.my_fun()}
+    _throwaway = Module22.my_fun()
+
+    Module18.my_fun()
   end
 end

--- a/test/elixir/support/fixtures/controller/module_6.ex
+++ b/test/elixir/support/fixtures/controller/module_6.ex
@@ -3,6 +3,7 @@ defmodule Hologram.Test.Fixtures.Controller.Module6 do
   use Hologram.Component
   alias Hologram.Component.Action
 
+  @impl Component
   def command(:my_command_a, _params, server) do
     %{server | next_action: nil}
   end

--- a/test/elixir/support/fixtures/controller/module_8.ex
+++ b/test/elixir/support/fixtures/controller/module_8.ex
@@ -3,6 +3,7 @@ defmodule Hologram.Test.Fixtures.Controller.Module8 do
   use Hologram.Component
   alias Hologram.Component.Action
 
+  @impl Component
   def command(:my_command_8, _params, server) do
     action = %Action{
       name: :my_action_8,

--- a/test/elixir/support/fixtures/controller/module_8.ex
+++ b/test/elixir/support/fixtures/controller/module_8.ex
@@ -3,7 +3,6 @@ defmodule Hologram.Test.Fixtures.Controller.Module8 do
   use Hologram.Component
   alias Hologram.Component.Action
 
-  @dialyzer {:nowarn_function, command: 3}
   @impl Component
   def command(:my_command_8, _params, server) do
     action = %Action{

--- a/test/elixir/support/fixtures/controller/module_8.ex
+++ b/test/elixir/support/fixtures/controller/module_8.ex
@@ -3,6 +3,7 @@ defmodule Hologram.Test.Fixtures.Controller.Module8 do
   use Hologram.Component
   alias Hologram.Component.Action
 
+  @dialyzer {:nowarn_function, command: 3}
   @impl Component
   def command(:my_command_8, _params, server) do
     action = %Action{
@@ -11,7 +12,7 @@ defmodule Hologram.Test.Fixtures.Controller.Module8 do
       target: nil
     }
 
-    %{server | next_action: action}
+    %Hologram.Server{server | next_action: action}
   end
 
   @impl Component

--- a/test/elixir/support/fixtures/controller/module_8.ex
+++ b/test/elixir/support/fixtures/controller/module_8.ex
@@ -12,7 +12,7 @@ defmodule Hologram.Test.Fixtures.Controller.Module8 do
       target: nil
     }
 
-    %Hologram.Server{server | next_action: action}
+    %{server | next_action: action}
   end
 
   @impl Component

--- a/test/elixir/support/fixtures/mix/tasks/holo/compiler/page_mfa_cascades/module_1.ex
+++ b/test/elixir/support/fixtures/mix/tasks/holo/compiler/page_mfa_cascades/module_1.ex
@@ -1,0 +1,23 @@
+# credo:disable-for-this-file Credo.Check.Readability.Specs
+defmodule Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageMfaCascades.Module1 do
+  use Hologram.Page
+
+  route "/hologram-test-fixtures-page-mfa-cascades-module1"
+
+  layout Hologram.Test.Fixtures.LayoutFixture
+
+  @impl Page
+  def template do
+    ~HOLO"""
+    Module1 template
+    """
+  end
+
+  @impl Page
+  def action(:test, _params, component) do
+    module = Map
+    module.get(%{a: 1}, :a)
+
+    put_state(component, :result, nil)
+  end
+end

--- a/test/elixir/support/fixtures/router/module_2.ex
+++ b/test/elixir/support/fixtures/router/module_2.ex
@@ -2,6 +2,7 @@
 defmodule Hologram.Test.Fixtures.Router.Module2 do
   use Hologram.Component
 
+  @impl Component
   def command(:my_command, _params, server) do
     %{server | next_action: nil}
   end


### PR DESCRIPTION
Allow users to add `@impl true` for all callbacks in pages and components.  Previously, only `int/3` and `template/0` were declared as callbacks.

Closes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Components and pages can now optionally declare additional init, action, and command handlers for more flexible behavior.

* **Tests**
  * Added tests that compile temporary modules and assert missing implementation annotations emit compiler warnings.

* **Chores**
  * Updated test fixtures to add explicit implementation annotations to align with the new optional-handler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->