### PR TITLE
Support Erlang dependency modules that use Elixir-style names

### DIFF
--- a/lib/hologram/reflection.ex
+++ b/lib/hologram/reflection.ex
@@ -120,6 +120,12 @@ defmodule Hologram.Reflection do
   @doc """
   Returns true if the given term is an existing Elixir module, or false otherwise.
 
+  Some Erlang modules use Elixir-style naming for interop (e.g. the atom `Luerl`,
+  whose source is the Erlang file `Elixir.Luerl.erl`). Such modules are compiled by
+  the Erlang compiler and are not Elixir modules, so they return false even though
+  their names look like Elixir aliases. They are detected by the absence of the
+  `__info__/1` function that the Elixir compiler injects into every Elixir module.
+
   ## Examples
 
       iex> elixir_module?(Calendar.ISO)
@@ -130,7 +136,7 @@ defmodule Hologram.Reflection do
 
       iex> elixir_module?(:my_module)
       false
-      
+
       iex> elixir_module?(123)
       false
   """
@@ -141,7 +147,7 @@ defmodule Hologram.Reflection do
     alias?(term) &&
       case Code.ensure_loaded(term) do
         {:module, _module} ->
-          true
+          function_exported?(term, :__info__, 1)
 
         _fallback ->
           false
@@ -153,6 +159,11 @@ defmodule Hologram.Reflection do
   @doc """
   Returns true if the given term is an existing Erlang module, or false otherwise.
 
+  An Erlang module is detected by the absence of the `__info__/1` function that the
+  Elixir compiler injects into every Elixir module. This means Erlang modules that
+  use Elixir-style naming for interop (e.g. the atom `Luerl`, whose source is the
+  Erlang file `Elixir.Luerl.erl`) are correctly recognized as Erlang modules.
+
   ## Examples
 
       iex> erlang_module?(:maps)
@@ -160,9 +171,9 @@ defmodule Hologram.Reflection do
 
       iex> erlang_module?(:my_module)
       false
-      
+
       iex> erlang_module?(Calendar.ISO)
-      false 
+      false
 
       iex> erlang_module?(123)
       false
@@ -171,19 +182,13 @@ defmodule Hologram.Reflection do
   def erlang_module?(term)
 
   def erlang_module?(term) when is_atom(term) do
-    first =
-      term
-      |> Atom.to_string()
-      |> String.first()
+    case Code.ensure_loaded(term) do
+      {:module, _module} ->
+        !function_exported?(term, :__info__, 1)
 
-    first >= "a" && first <= "z" &&
-      case Code.ensure_loaded(term) do
-        {:module, _module} ->
-          true
-
-        _fallback ->
-          false
-      end
+      _fallback ->
+        false
+    end
   end
 
   def erlang_module?(_term), do: false

--- a/test/elixir/hologram/reflection_test.exs
+++ b/test/elixir/hologram/reflection_test.exs
@@ -10,6 +10,36 @@ defmodule Hologram.ReflectionTest do
   alias Hologram.Test.Fixtures.Reflection.Module8
   alias Hologram.Test.Fixtures.Reflection.Module9
 
+  # Reproduces the way some Erlang libraries (e.g. luerl) name their modules with an
+  # "Elixir." prefix for interop. Such modules are compiled by the Erlang compiler, so
+  # they lack the __info__/1 function that the Elixir compiler injects, and must not be
+  # treated as Elixir modules.
+  defp build_elixir_named_erlang_module do
+    module = Hologram.Test.Fixtures.Reflection.ErlangModuleWithElixirName
+
+    sources = [
+      "-module('#{module}').",
+      "-export([my_fun/0]).",
+      "my_fun() -> my_value."
+    ]
+
+    forms =
+      Enum.map(sources, fn source ->
+        charlist = String.to_charlist(source)
+        :merl.quote(charlist)
+      end)
+
+    {:ok, ^module, binary} = :compile.forms(forms, [:debug_info])
+    {:module, ^module} = :code.load_binary(module, ~c"nofile", binary)
+
+    on_exit(fn ->
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    module
+  end
+
   describe "alias?/1" do
     test "atom which is an alias" do
       assert alias?(Calendar.ISO)
@@ -103,6 +133,10 @@ defmodule Hologram.ReflectionTest do
       refute elixir_module?(:maps)
     end
 
+    test "Erlang module that uses Elixir-style naming" do
+      refute elixir_module?(build_elixir_named_erlang_module())
+    end
+
     test "atom that starts with a lowercase letter and is not an existing Erlang module" do
       refute elixir_module?(:my_module)
     end
@@ -127,6 +161,10 @@ defmodule Hologram.ReflectionTest do
 
     test "existing Erlang module" do
       assert erlang_module?(:maps)
+    end
+
+    test "Erlang module that uses Elixir-style naming" do
+      assert erlang_module?(build_elixir_named_erlang_module())
     end
 
     test "atom that starts with a lowercase letter and is not an existing Erlang module" do


### PR DESCRIPTION
Closes #776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced module-type detection logic to accurately classify Erlang and Elixir modules, including proper handling of edge cases with non-standard naming patterns.

* **Documentation**
  * Updated module-detection documentation to reflect revised detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->