### PR TITLE
Support umbrella projects

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -11,6 +11,7 @@
           ~r"/deps/",
           ~r"/node_modules/",
           "test/features/",
+          "test/elixir/support/fixtures/live_reload/umbrella",
           "test/elixir/support/fixtures/compiler/normalizer/module_7.ex",
           "test/elixir/support/fixtures/compiler/normalizer/module_8.ex"
         ]

--- a/lib/hologram/compiler.ex
+++ b/lib/hologram/compiler.ex
@@ -303,13 +303,18 @@ defmodule Hologram.Compiler do
       "--target=es2021"
     ]
 
-    project_node_modules_path = Path.join([Reflection.root_dir(), "assets", "node_modules"])
+    # Include both the workspace root (umbrella root or single-app root) and
+    # the current project root (umbrella child app or single-app root) so that
+    # whichever layout the user has, NODE_PATH points at their node_modules.
+    # Non-existent directories on NODE_PATH are silently ignored by Node.
+    project_node_modules_paths =
+      [Reflection.workspace_root_dir(), Reflection.root_dir()]
+      |> Enum.uniq()
+      |> Enum.map(&Path.join([&1, "assets", "node_modules"]))
 
     node_path =
-      Enum.join(
-        [opts[:node_modules_path], project_node_modules_path],
-        PathUtils.env_path_separator()
-      )
+      [opts[:node_modules_path] | project_node_modules_paths]
+      |> Enum.join(PathUtils.env_path_separator())
 
     esbuild_opts = [
       env: [{"NODE_PATH", node_path}],

--- a/lib/hologram/compiler.ex
+++ b/lib/hologram/compiler.ex
@@ -312,9 +312,10 @@ defmodule Hologram.Compiler do
       |> Enum.uniq()
       |> Enum.map(&Path.join([&1, "assets", "node_modules"]))
 
-    node_path =
-      [opts[:node_modules_path] | project_node_modules_paths]
-      |> Enum.join(PathUtils.env_path_separator())
+    node_path = Enum.join(
+      [opts[:node_modules_path] | project_node_modules_paths],
+      PathUtils.env_path_separator()
+    )
 
     esbuild_opts = [
       env: [{"NODE_PATH", node_path}],

--- a/lib/hologram/compiler.ex
+++ b/lib/hologram/compiler.ex
@@ -312,10 +312,11 @@ defmodule Hologram.Compiler do
       |> Enum.uniq()
       |> Enum.map(&Path.join([&1, "assets", "node_modules"]))
 
-    node_path = Enum.join(
-      [opts[:node_modules_path] | project_node_modules_paths],
-      PathUtils.env_path_separator()
-    )
+    node_path =
+      Enum.join(
+        [opts[:node_modules_path] | project_node_modules_paths],
+        PathUtils.env_path_separator()
+      )
 
     esbuild_opts = [
       env: [{"NODE_PATH", node_path}],

--- a/lib/hologram/generators/ai_rules.ex
+++ b/lib/hologram/generators/ai_rules.ex
@@ -10,7 +10,7 @@ defmodule Hologram.Generators.AIRules do
   Syncs an AI rules file (e.g. AGENTS.md, CLAUDE.md) with Hologram rules wrapped in markers.
 
   Options:
-    * `:source_path` - path to the rules source file (defaults to deps/hologram/usage-rules.md)
+    * `:source_path` - path to the rules source file (defaults to the Hologram dependency's usage-rules.md)
     * `:target_dir` - target directory (defaults to current working directory)
   """
   @spec sync(String.t(), keyword()) :: :ok
@@ -51,7 +51,7 @@ defmodule Hologram.Generators.AIRules do
   end
 
   defp default_source_path do
-    Path.join(Reflection.root_dir(), "deps/hologram/usage-rules.md")
+    Path.join(Reflection.hologram_dep_dir(), "usage-rules.md")
   end
 
   defp print(output) do

--- a/lib/hologram/live_reload.ex
+++ b/lib/hologram/live_reload.ex
@@ -75,7 +75,7 @@ defmodule Hologram.LiveReload do
 
   @doc """
   Reloads the application after a file change by recompiling Elixir code,
-  recompiling Hologram components, reloading Hologram runtime, and 
+  recompiling Hologram components, reloading Hologram runtime, and
   broadcasting reload notifications to connected clients.
 
   If code reloading fails, broadcasts a compilation error instead.
@@ -108,7 +108,7 @@ defmodule Hologram.LiveReload do
     case Mix.Project.apps_paths() do
       nil ->
         root_dir = Reflection.root_dir()
-        compiled_paths = Mix.Project.get().project()[:elixirc_paths]
+        compiled_paths = Mix.Project.get().project()[:elixirc_paths] || ["lib"]
         Enum.map(compiled_paths, &Path.join(root_dir, &1))
 
       apps_paths ->
@@ -117,15 +117,17 @@ defmodule Hologram.LiveReload do
         # the watcher gets absolute paths regardless of cwd at watch time.
         Enum.flat_map(apps_paths, fn {app, app_path} ->
           abs_app_path = Path.expand(app_path)
-
-          compiled_paths =
-            Mix.Project.in_project(app, abs_app_path, fn _module ->
-              Mix.Project.config()[:elixirc_paths] || ["lib"]
-            end)
+          compiled_paths = traverse_path_in_project(app, abs_app_path)
 
           Enum.map(compiled_paths, &Path.join(abs_app_path, &1))
         end)
     end
+  end
+
+  defp traverse_path_in_project(app, abs_app_path) do
+    Mix.Project.in_project(app, abs_app_path, fn _module ->
+      Mix.Project.config()[:elixirc_paths] || ["lib"]
+    end)
   end
 
   @doc """

--- a/lib/hologram/live_reload.ex
+++ b/lib/hologram/live_reload.ex
@@ -96,14 +96,36 @@ defmodule Hologram.LiveReload do
   @doc """
   Returns the list of directories that are watched for file changes.
 
-  The directories are determined by the project's `:elixirc_paths` configuration
-  and are converted to absolute paths based on the project root directory.
+  In a single-app project the directories are the project's own
+  `:elixirc_paths`, joined to the project root.
+
+  In an umbrella project they are the union of every child app's
+  `:elixirc_paths`, joined to that child app's directory - so changes in any
+  child app trigger a reload.
   """
   @spec watched_dirs :: [String.t()]
   def watched_dirs do
-    root_dir = Reflection.root_dir()
-    compiled_paths = Mix.Project.get().project()[:elixirc_paths]
-    Enum.map(compiled_paths, &Path.join(root_dir, &1))
+    case Mix.Project.apps_paths() do
+      nil ->
+        root_dir = Reflection.root_dir()
+        compiled_paths = Mix.Project.get().project()[:elixirc_paths]
+        Enum.map(compiled_paths, &Path.join(root_dir, &1))
+
+      apps_paths ->
+        # `Mix.Project.apps_paths/0` returns paths relative to the umbrella
+        # root (the current cwd while it's the active project). Expand here so
+        # the watcher gets absolute paths regardless of cwd at watch time.
+        Enum.flat_map(apps_paths, fn {app, app_path} ->
+          abs_app_path = Path.expand(app_path)
+
+          compiled_paths =
+            Mix.Project.in_project(app, abs_app_path, fn _module ->
+              Mix.Project.config()[:elixirc_paths] || ["lib"]
+            end)
+
+          Enum.map(compiled_paths, &Path.join(abs_app_path, &1))
+        end)
+    end
   end
 
   @doc """

--- a/lib/hologram/reflection.ex
+++ b/lib/hologram/reflection.ex
@@ -40,7 +40,7 @@ defmodule Hologram.Reflection do
 
   ## Examples
 
-      iex> beam_path = ~c"/Users/bartblast/Projects/hologram/_build/dev/lib/hologram/ebin/Elixir.Hologram.Reflection.beam"  
+      iex> beam_path = ~c"/Users/bartblast/Projects/hologram/_build/dev/lib/hologram/ebin/Elixir.Hologram.Reflection.beam"
       iex> beam_defs()
       [
         ...,
@@ -371,13 +371,13 @@ defmodule Hologram.Reflection do
 
       iex> module?(MyModule)
       false
-      
+
       iex> module?(:maps)
       true
 
       iex> module?(:my_module)
       false
-      
+
       iex> module?(123)
       false
   """
@@ -554,7 +554,7 @@ defmodule Hologram.Reflection do
   """
   @spec workspace_root_dir() :: String.t()
   def workspace_root_dir do
-    Mix.Project.deps_path() |> Path.dirname()
+    Path.dirname(Mix.Project.deps_path())
   end
 
   @doc """
@@ -574,7 +574,7 @@ defmodule Hologram.Reflection do
 
       iex> component?(MyComponent)
       true
-      
+
       iex> component?(MyPage)
       true
 

--- a/lib/hologram/reflection.ex
+++ b/lib/hologram/reflection.ex
@@ -78,6 +78,18 @@ defmodule Hologram.Reflection do
   end
 
   @doc """
+  Returns the absolute path of the Hologram dependency directory.
+
+  Resolved via `Mix.Project.deps_path/0`, which yields the umbrella's shared
+  `deps/` directory when called inside a child app, and `<project>/deps` for a
+  single-app project.
+  """
+  @spec hologram_dep_dir() :: String.t()
+  def hologram_dep_dir do
+    Path.join(Mix.Project.deps_path(), "hologram")
+  end
+
+  @doc """
   Returns the call graph dump file name.
   """
   @spec call_graph_dump_file_name() :: String.t()
@@ -530,6 +542,19 @@ defmodule Hologram.Reflection do
   @spec root_priv_dir() :: String.t()
   def root_priv_dir do
     Path.join([root_dir(), "priv", "hologram"])
+  end
+
+  @doc """
+  Returns the absolute path of the workspace root.
+
+  In an umbrella project this is the umbrella's root directory (the parent of
+  `apps/`); in a single-app project it is the project root. Useful for finding
+  files that conventionally live at the top of the workspace (assets,
+  `node_modules`).
+  """
+  @spec workspace_root_dir() :: String.t()
+  def workspace_root_dir do
+    Mix.Project.deps_path() |> Path.dirname()
   end
 
   @doc """

--- a/lib/mix/tasks/compile/hologram.ex
+++ b/lib/mix/tasks/compile/hologram.ex
@@ -50,8 +50,7 @@ defmodule Mix.Tasks.Compile.Hologram do
   end
 
   defp build_default_opts do
-    root_dir = Reflection.root_dir()
-    assets_dir = Path.join([root_dir, "deps", "hologram", "assets"])
+    assets_dir = Path.join(Reflection.hologram_dep_dir(), "assets")
     build_dir = Reflection.build_dir()
     node_modules_path = Path.join(assets_dir, "node_modules")
 
@@ -61,7 +60,7 @@ defmodule Mix.Tasks.Compile.Hologram do
       esbuild_bin_path: Path.join([node_modules_path, ".bin", "esbuild"]),
       js_dir: Path.join(assets_dir, "js"),
       node_modules_path: node_modules_path,
-      static_dir: Path.join([root_dir, "priv", "static", "hologram"]),
+      static_dir: Path.join([Reflection.root_dir(), "priv", "static", "hologram"]),
       tmp_dir: Path.join(build_dir, "tmp")
     ]
   end

--- a/test/elixir/hologram/live_reload_test.exs
+++ b/test/elixir/hologram/live_reload_test.exs
@@ -137,19 +137,41 @@ defmodule Hologram.LiveReloadTest do
     end
   end
 
-  test "watched_dirs/0" do
-    result = LiveReload.watched_dirs()
+  describe "watched_dirs/0" do
+    test "single-app project" do
+      result = LiveReload.watched_dirs()
 
-    # Should return a list of string paths
-    assert is_list(result)
-    assert Enum.all?(result, &is_binary/1)
+      # Should return a list of string paths
+      assert is_list(result)
+      assert Enum.all?(result, &is_binary/1)
 
-    # All paths should be absolute
-    assert Enum.all?(result, fn path -> Path.type(path) == :absolute end)
+      # All paths should be absolute
+      assert Enum.all?(result, fn path -> Path.type(path) == :absolute end)
 
-    # Should contain the lib directory (standard in elixirc_paths)
-    lib_path = Path.join([File.cwd!(), "lib"])
-    assert lib_path in result
+      # Should contain the lib directory (standard in elixirc_paths)
+      lib_path = Path.join([File.cwd!(), "lib"])
+      assert lib_path in result
+    end
+
+    test "umbrella project" do
+      umbrella_dir =
+        Path.join([
+          File.cwd!(),
+          "test/elixir/support/fixtures/live_reload/umbrella"
+        ])
+
+      app_a_dir = Path.join(umbrella_dir, "apps/app_a")
+      app_b_dir = Path.join(umbrella_dir, "apps/app_b")
+
+      result =
+        Mix.Project.in_project(:umbrella_under_test, umbrella_dir, fn _module ->
+          LiveReload.watched_dirs()
+        end)
+
+      assert Path.join(app_a_dir, "lib") in result
+      assert Path.join(app_b_dir, "lib") in result
+      assert Path.join(app_b_dir, "support") in result
+    end
   end
 
   describe "watcher_opts/1" do

--- a/test/elixir/hologram/reflection_test.exs
+++ b/test/elixir/hologram/reflection_test.exs
@@ -476,6 +476,14 @@ defmodule Hologram.ReflectionTest do
     assert root_priv_dir() == File.cwd!() <> "/priv/hologram"
   end
 
+  test "hologram_dep_dir/0" do
+    assert hologram_dep_dir() == Path.join(Mix.Project.deps_path(), "hologram")
+  end
+
+  test "workspace_root_dir/0" do
+    assert workspace_root_dir() == Path.dirname(Mix.Project.deps_path())
+  end
+
   test "source_path/1" do
     assert source_path(__MODULE__) == __ENV__.file
   end

--- a/test/elixir/support/fixtures/live_reload/umbrella/apps/app_a/mix.exs
+++ b/test/elixir/support/fixtures/live_reload/umbrella/apps/app_a/mix.exs
@@ -1,0 +1,11 @@
+defmodule Hologram.Test.Fixtures.LiveReload.Umbrella.AppA.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app_a,
+      elixirc_paths: ["lib"],
+      version: "0.0.0"
+    ]
+  end
+end

--- a/test/elixir/support/fixtures/live_reload/umbrella/apps/app_b/mix.exs
+++ b/test/elixir/support/fixtures/live_reload/umbrella/apps/app_b/mix.exs
@@ -1,0 +1,11 @@
+defmodule Hologram.Test.Fixtures.LiveReload.Umbrella.AppB.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app_b,
+      elixirc_paths: ["lib", "support"],
+      version: "0.0.0"
+    ]
+  end
+end

--- a/test/elixir/support/fixtures/live_reload/umbrella/mix.exs
+++ b/test/elixir/support/fixtures/live_reload/umbrella/mix.exs
@@ -1,0 +1,10 @@
+defmodule Hologram.Test.Fixtures.LiveReload.Umbrella.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      apps_path: "apps",
+      version: "0.0.0"
+    ]
+  end
+end


### PR DESCRIPTION
Closes #875 

There is a problem with Hologram when you trying to use it in a Umbrella application.
Problem starts when you try to run out `mix holo` on a Umbrella app, it just crashes on live reloading.

If you go down deep into particular folder you will have a problem with building assets.
This PR fixes problem, but leaving limitation there is can be possible only one Hologram used in Umbrella application. (And it should also be a BC).

Which also IMO should be fixed/implemented in future, in e.g. (you can have Hologram for admin and Hologram for web-facing user-application). But i don't see how to quickly implement it without BC. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Live reload now monitors source directories across all umbrella child apps and single-app projects.
  * Asset and workspace path resolution improved for multi-app workspaces.
  * Default AI rules source path now points to the packaged dependency location.

* **Tests**
  * Added umbrella fixtures and tests validating live-reload directories and new directory-helper utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->