### PR TITLE
Implement `holo.compiler.page_to_mfa_paths` Mix task

### DIFF
--- a/lib/mix/tasks/holo/compiler/page_ex_fun_sizes.ex
+++ b/lib/mix/tasks/holo/compiler/page_ex_fun_sizes.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Holo.Compiler.PageExFunSizes do
 
       $ mix holo.compiler.page_ex_fun_sizes MyPageModule 
 
-  Where `MyPageModule` is the name of the page module you want to analyze (without the `Elixir.` prefix).
+  Where `MyPageModule` is the name of the page module you want to analyze.
   """
 
   use Mix.Task

--- a/lib/mix/tasks/holo/compiler/page_to_mfa_paths.ex
+++ b/lib/mix/tasks/holo/compiler/page_to_mfa_paths.ex
@@ -1,0 +1,51 @@
+defmodule Mix.Tasks.Holo.Compiler.PageToMfaPaths do
+  @moduledoc """
+  Prints paths from page entry MFAs to the given destination MFA.
+
+  ## Examples
+
+      $ mix holo.compiler.page_to_mfa_paths MyPageModule "{MyModule, :my_fun, 2}"
+
+  Where `MyPageModule` is the name of the page module and
+  `{MyModule, :my_fun, 2}` is the destination MFA.
+  """
+
+  use Mix.Task
+
+  alias Hologram.Compiler
+  alias Hologram.Compiler.CallGraph
+  alias Hologram.Compiler.Digraph
+
+  @requirements ["app.config"]
+
+  @doc false
+  @impl Mix.Task
+  def run([page_module_arg, dest_mfa_arg]) do
+    page_module = String.to_existing_atom("Elixir." <> page_module_arg)
+    {dest_mfa, _binding} = Code.eval_string(dest_mfa_arg)
+
+    graph =
+      Compiler.build_call_graph()
+      |> CallGraph.remove_manually_ported_mfas()
+      |> remove_runtime_mfas()
+      |> CallGraph.get_graph()
+
+    page_module
+    |> CallGraph.list_page_entry_mfas()
+    |> Enum.each(fn entry_mfa ->
+      shortest_path = Digraph.shortest_path(graph, entry_mfa, dest_mfa)
+
+      if shortest_path do
+        # credo:disable-for-next-line Credo.Check.Refactor.IoPuts
+        IO.puts("\n#{inspect(entry_mfa)} -> #{inspect(dest_mfa)}\n#{inspect(shortest_path)}\n")
+      end
+    end)
+
+    :ok
+  end
+
+  defp remove_runtime_mfas(call_graph) do
+    runtime_mfas = CallGraph.list_runtime_mfas(call_graph)
+    CallGraph.remove_runtime_mfas!(call_graph, runtime_mfas)
+  end
+end

--- a/lib/mix/tasks/holo/compiler/runtime_to_mfa_paths.ex
+++ b/lib/mix/tasks/holo/compiler/runtime_to_mfa_paths.ex
@@ -1,6 +1,12 @@
 defmodule Mix.Tasks.Holo.Compiler.RuntimeToMfaPaths do
   @moduledoc """
   Prints paths from runtime entry MFAs to the given destination MFA.
+
+  ## Examples
+
+      $ mix holo.compiler.runtime_to_mfa_paths "{MyModule, :my_fun, 2}"
+
+  Where `{MyModule, :my_fun, 2}` is the destination MFA.
   """
 
   use Mix.Task

--- a/test/elixir/mix/tasks/holo/compiler/page_to_mfa_paths_test.exs
+++ b/test/elixir/mix/tasks/holo/compiler/page_to_mfa_paths_test.exs
@@ -1,0 +1,24 @@
+defmodule Mix.Tasks.Holo.Compiler.PageToMfaPathsTest do
+  use Hologram.Test.BasicCase, async: true
+  import ExUnit.CaptureIO
+  alias Mix.Tasks.Holo.Compiler.PageToMfaPaths, as: Task
+
+  test "run/1" do
+    page_module_arg = "Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1"
+
+    dest_mfa_arg =
+      "{Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module3, :fun_3c, 0}"
+
+    output =
+      capture_io(fn ->
+        assert Task.run([page_module_arg, dest_mfa_arg]) == :ok
+      end)
+
+    assert output == """
+
+           {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :template, 0} -> {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module3, :fun_3c, 0}
+           [{Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :template, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :fun_1a, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module2, :fun_2b, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module3, :fun_3c, 0}]
+
+           """
+  end
+end

--- a/test/elixir/mix/tasks/holo/compiler/page_to_mfa_paths_test.exs
+++ b/test/elixir/mix/tasks/holo/compiler/page_to_mfa_paths_test.exs
@@ -14,11 +14,14 @@ defmodule Mix.Tasks.Holo.Compiler.PageToMfaPathsTest do
         assert Task.run([page_module_arg, dest_mfa_arg]) == :ok
       end)
 
-    assert output == """
+    expected =
+      normalize_newlines("""
 
-           {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :template, 0} -> {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module3, :fun_3c, 0}
-           [{Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :template, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :fun_1a, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module2, :fun_2b, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module3, :fun_3c, 0}]
+      {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :template, 0} -> {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module3, :fun_3c, 0}
+      [{Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :template, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module1, :fun_1a, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module2, :fun_2b, 0}, {Hologram.Test.Fixtures.Mix.Tasks.Holo.Compiler.PageToMfaPaths.Module3, :fun_3c, 0}]
 
-           """
+      """)
+
+    assert output == expected
   end
 end


### PR DESCRIPTION
Closes #883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Mix task to trace and display the shortest path from page entry MFAs to a specified destination MFA.

* **Documentation**
  * Improved module documentation with clearer usage examples for the compiler analysis tasks.

* **Tests**
  * Added coverage for the new page-to-MFA tracing Mix task, including output verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->