### PR TITLE
Add text selection primitives

### DIFF
--- a/assets/js/component_registry.mjs
+++ b/assets/js/component_registry.mjs
@@ -9,6 +9,16 @@ export default class ComponentRegistry {
     ComponentRegistry.entries = Type.map();
   }
 
+  // Optimized (mutates dom_effects field in-place)
+  static clearDomEffects(cid) {
+    const entry = ComponentRegistry.entries.data[Type.encodeMapKey(cid)][1];
+    const componentStruct = entry.data["atom(struct)"][1];
+    componentStruct.data["atom(dom_effects)"] = [
+      Type.atom("dom_effects"),
+      Type.list(),
+    ];
+  }
+
   // Optimized (mutates next_action field in-place)
   static clearNextAction(cid) {
     const entry = ComponentRegistry.entries.data[Type.encodeMapKey(cid)][1];

--- a/assets/js/dom_selection.mjs
+++ b/assets/js/dom_selection.mjs
@@ -1,0 +1,199 @@
+"use strict";
+
+const DOCUMENT_POSITION_PRECEDING = 2;
+const DOCUMENT_POSITION_FOLLOWING = 4;
+
+export default class DomSelection {
+  static buildDomSelection(root, selection = window.getSelection?.()) {
+    if (!root || !selection || selection.rangeCount === 0) {
+      return null;
+    }
+
+    const {anchorNode, anchorOffset, focusNode, focusOffset} = selection;
+
+    if (!$.contains(root, anchorNode) || !$.contains(root, focusNode)) {
+      return null;
+    }
+
+    const anchorPath = $.nodePath(root, anchorNode);
+    const focusPath = $.nodePath(root, focusNode);
+
+    if (anchorPath === null || focusPath === null) {
+      return null;
+    }
+
+    return {
+      anchorPath,
+      anchorOffset,
+      focusPath,
+      focusOffset,
+      direction: $.direction(selection),
+      value: selection.toString(),
+    };
+  }
+
+  static buildTextControlSelection(element) {
+    if (!$.isTextControl(element)) {
+      return null;
+    }
+
+    const selectionStart = $.readSelectionNumber(element, "selectionStart");
+    const selectionEnd = $.readSelectionNumber(element, "selectionEnd");
+
+    if (selectionStart === null || selectionEnd === null) {
+      return null;
+    }
+
+    return {
+      selectionStart,
+      selectionEnd,
+      selectionDirection: $.readSelectionDirection(element),
+    };
+  }
+
+  static contains(root, node) {
+    return !!root && !!node && (root === node || root.contains(node));
+  }
+
+  static direction(selection) {
+    if (selection.isCollapsed) {
+      return "none";
+    }
+
+    const {anchorNode, anchorOffset, focusNode, focusOffset} = selection;
+
+    if (anchorNode === focusNode) {
+      return anchorOffset <= focusOffset ? "forward" : "backward";
+    }
+
+    const position = anchorNode.compareDocumentPosition(focusNode);
+
+    if (position & DOCUMENT_POSITION_FOLLOWING) {
+      return "forward";
+    }
+
+    if (position & DOCUMENT_POSITION_PRECEDING) {
+      return "backward";
+    }
+
+    return "none";
+  }
+
+  static isTextControl(element) {
+    return (
+      !!element &&
+      (element.tagName === "INPUT" || element.tagName === "TEXTAREA") &&
+      typeof element.value === "string"
+    );
+  }
+
+  static nodeFromPath(root, path) {
+    if (!root || !Array.isArray(path)) {
+      return null;
+    }
+
+    let node = root;
+
+    for (const index of path) {
+      node = node.childNodes[index];
+
+      if (!node) {
+        return null;
+      }
+    }
+
+    return node;
+  }
+
+  static nodePath(root, node) {
+    if (!$.contains(root, node)) {
+      return null;
+    }
+
+    const path = [];
+    let current = node;
+
+    while (current !== root) {
+      const parent = current.parentNode;
+
+      if (!parent) {
+        return null;
+      }
+
+      path.unshift(Array.prototype.indexOf.call(parent.childNodes, current));
+      current = parent;
+    }
+
+    return path;
+  }
+
+  static readSelectionDirection(element) {
+    try {
+      return typeof element.selectionDirection === "string"
+        ? element.selectionDirection
+        : "none";
+    } catch {
+      return "none";
+    }
+  }
+
+  static readSelectionNumber(element, property) {
+    try {
+      const value = element[property];
+      return Number.isInteger(value) ? value : null;
+    } catch {
+      return null;
+    }
+  }
+
+  static restoreDomSelection(root, domSelection) {
+    const selection = window.getSelection?.();
+
+    if (!selection) {
+      return false;
+    }
+
+    const anchorNode = $.nodeFromPath(root, domSelection.anchorPath);
+    const focusNode = $.nodeFromPath(root, domSelection.focusPath);
+
+    if (!anchorNode || !focusNode) {
+      return false;
+    }
+
+    root.focus?.();
+    selection.removeAllRanges();
+
+    if (typeof selection.setBaseAndExtent === "function") {
+      try {
+        selection.setBaseAndExtent(
+          anchorNode,
+          domSelection.anchorOffset,
+          focusNode,
+          domSelection.focusOffset,
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    const range = document.createRange();
+
+    try {
+      range.setStart(anchorNode, domSelection.anchorOffset);
+      range.setEnd(focusNode, domSelection.focusOffset);
+    } catch {
+      try {
+        range.setStart(focusNode, domSelection.focusOffset);
+        range.setEnd(anchorNode, domSelection.anchorOffset);
+      } catch {
+        return false;
+      }
+    }
+
+    selection.addRange(range);
+    return true;
+  }
+}
+
+const $ = DomSelection;

--- a/assets/js/events/before_input_event.mjs
+++ b/assets/js/events/before_input_event.mjs
@@ -1,0 +1,89 @@
+"use strict";
+
+import DomSelection from "../dom_selection.mjs";
+import Type from "../type.mjs";
+
+export default class BeforeInputEvent {
+  static isDefaultAllowed = false;
+
+  static buildOperationParam(event) {
+    const target = event.target;
+    const root = event.currentTarget || target;
+    const textSelection = DomSelection.buildTextControlSelection(target);
+    const domSelection =
+      textSelection === null ? DomSelection.buildDomSelection(root) : null;
+
+    return Type.map([
+      [Type.atom("input_type"), Type.bitstring(event.inputType || "")],
+      [Type.atom("data"), $.boxNullableBitstring(event.data)],
+      [Type.atom("is_composing"), Type.boolean(event.isComposing === true)],
+      [Type.atom("selection"), $.boxSelection(textSelection, domSelection)],
+      [
+        Type.atom("selection_start"),
+        textSelection === null
+          ? Type.nil()
+          : Type.integer(textSelection.selectionStart),
+      ],
+      [
+        Type.atom("selection_end"),
+        textSelection === null
+          ? Type.nil()
+          : Type.integer(textSelection.selectionEnd),
+      ],
+      [
+        Type.atom("selection_direction"),
+        textSelection === null
+          ? Type.nil()
+          : Type.bitstring(textSelection.selectionDirection),
+      ],
+    ]);
+  }
+
+  static boxDomSelection(selection) {
+    if (selection === null) {
+      return Type.nil();
+    }
+
+    return Type.map([
+      [Type.atom("anchor_path"), $.boxPath(selection.anchorPath)],
+      [Type.atom("anchor_offset"), Type.integer(selection.anchorOffset)],
+      [Type.atom("focus_path"), $.boxPath(selection.focusPath)],
+      [Type.atom("focus_offset"), Type.integer(selection.focusOffset)],
+      [Type.atom("direction"), Type.bitstring(selection.direction)],
+    ]);
+  }
+
+  static boxNullableBitstring(value) {
+    return value === null || typeof value === "undefined"
+      ? Type.nil()
+      : Type.bitstring(value);
+  }
+
+  static boxPath(path) {
+    return Type.list(path.map((index) => Type.integer(index)));
+  }
+
+  static boxSelection(textSelection, domSelection) {
+    if (textSelection !== null) {
+      return Type.map([
+        [
+          Type.atom("selection_start"),
+          Type.integer(textSelection.selectionStart),
+        ],
+        [Type.atom("selection_end"), Type.integer(textSelection.selectionEnd)],
+        [
+          Type.atom("selection_direction"),
+          Type.bitstring(textSelection.selectionDirection),
+        ],
+      ]);
+    }
+
+    return $.boxDomSelection(domSelection);
+  }
+
+  static isEventIgnored(_event) {
+    return false;
+  }
+}
+
+const $ = BeforeInputEvent;

--- a/assets/js/events/select_event.mjs
+++ b/assets/js/events/select_event.mjs
@@ -1,17 +1,41 @@
 "use strict";
 
+import DomSelection from "../dom_selection.mjs";
 import Type from "../type.mjs";
 
 export default class SelectEvent {
   static isDefaultAllowed = false;
 
   static buildOperationParam(event) {
-    const value = event.target.value.substring(
-      event.target.selectionStart,
-      event.target.selectionEnd,
-    );
+    const selection = DomSelection.buildTextControlSelection(event.target);
 
-    return Type.map([[Type.atom("value"), Type.bitstring(value)]]);
+    const value =
+      selection === null
+        ? ""
+        : event.target.value.substring(
+            selection.selectionStart,
+            selection.selectionEnd,
+          );
+
+    return Type.map([
+      [Type.atom("value"), Type.bitstring(value)],
+      [
+        Type.atom("selection_start"),
+        selection === null
+          ? Type.nil()
+          : Type.integer(selection.selectionStart),
+      ],
+      [
+        Type.atom("selection_end"),
+        selection === null ? Type.nil() : Type.integer(selection.selectionEnd),
+      ],
+      [
+        Type.atom("selection_direction"),
+        selection === null
+          ? Type.nil()
+          : Type.bitstring(selection.selectionDirection),
+      ],
+    ]);
   }
 
   static isEventIgnored(_event) {

--- a/assets/js/events/selection_change_event.mjs
+++ b/assets/js/events/selection_change_event.mjs
@@ -1,0 +1,44 @@
+"use strict";
+
+import DomSelection from "../dom_selection.mjs";
+import Type from "../type.mjs";
+
+export default class SelectionChangeEvent {
+  static isDefaultAllowed = true;
+
+  static buildOperationParam(event) {
+    const selection = DomSelection.buildDomSelection(event.currentTarget);
+
+    return Type.map([
+      [
+        Type.atom("value"),
+        Type.bitstring(selection === null ? "" : selection.value),
+      ],
+      [Type.atom("selection"), $.boxDomSelection(selection)],
+    ]);
+  }
+
+  static boxDomSelection(selection) {
+    if (selection === null) {
+      return Type.nil();
+    }
+
+    return Type.map([
+      [Type.atom("anchor_path"), $.boxPath(selection.anchorPath)],
+      [Type.atom("anchor_offset"), Type.integer(selection.anchorOffset)],
+      [Type.atom("focus_path"), $.boxPath(selection.focusPath)],
+      [Type.atom("focus_offset"), Type.integer(selection.focusOffset)],
+      [Type.atom("direction"), Type.bitstring(selection.direction)],
+    ]);
+  }
+
+  static boxPath(path) {
+    return Type.list(path.map((index) => Type.integer(index)));
+  }
+
+  static isEventIgnored(event) {
+    return DomSelection.buildDomSelection(event.currentTarget) === null;
+  }
+}
+
+const $ = SelectionChangeEvent;

--- a/assets/js/hologram.mjs
+++ b/assets/js/hologram.mjs
@@ -7,6 +7,7 @@ import Client from "./client.mjs";
 import ComponentRegistry from "./component_registry.mjs";
 import Config from "./config.mjs";
 import Deserializer from "./deserializer.mjs";
+import DomSelection from "./dom_selection.mjs";
 import ERTS from "./erts.mjs";
 import EventListenerRegistry from "./event_listener_registry.mjs";
 import GlobalRegistry from "./global_registry.mjs";
@@ -27,6 +28,7 @@ import Utils from "./utils.mjs";
 import Vdom from "./vdom.mjs";
 
 // Events
+import BeforeInputEvent from "./events/before_input_event.mjs";
 import ChangeEvent from "./events/change_event.mjs";
 import ClickEvent from "./events/click_event.mjs";
 import ClickOutsideEvent from "./events/click_outside_event.mjs";
@@ -38,6 +40,7 @@ import PointerEvent from "./events/pointer_event.mjs";
 import ResizeEvent from "./events/resize_event.mjs";
 import ScrollEvent from "./events/scroll_event.mjs";
 import SelectEvent from "./events/select_event.mjs";
+import SelectionChangeEvent from "./events/selection_change_event.mjs";
 import SubmitEvent from "./events/submit_event.mjs";
 import TransitionEvent from "./events/transition_event.mjs";
 
@@ -379,6 +382,8 @@ export default class Hologram {
       ...Renderer.resolveResizeBindings(),
     ]);
 
+    Hologram.#executeDomEffects();
+
     console.log("Hologram: page rendered in", PerformanceTimer.diff(startTime));
   }
 
@@ -671,6 +676,111 @@ export default class Hologram {
     }
   }
 
+  static #executeDomEffect(effect) {
+    const type = Hologram.#getDomEffectValue(effect, "type");
+
+    if (Type.isNil(type)) {
+      return;
+    }
+
+    switch (type.value) {
+      case "focus":
+        Hologram.#executeFocusEffect(effect);
+        return;
+
+      case "text_selection":
+        Hologram.#executeTextSelectionEffect(effect);
+        return;
+
+      case "dom_selection":
+        Hologram.#executeDomSelectionEffect(effect);
+    }
+  }
+
+  static #executeDomEffects() {
+    for (const [cid, entry] of Object.values(ComponentRegistry.entries.data)) {
+      const componentStruct = Erlang_Maps["get/2"](Type.atom("struct"), entry);
+
+      const effects = Erlang_Maps["get/3"](
+        Type.atom("dom_effects"),
+        componentStruct,
+        Type.list(),
+      );
+
+      if (!Type.isList(effects) || effects.data.length === 0) {
+        continue;
+      }
+
+      effects.data.forEach((effect) => Hologram.#executeDomEffect(effect));
+      ComponentRegistry.clearDomEffects(cid);
+    }
+  }
+
+  static #executeDomSelectionEffect(effect) {
+    const rootId = Hologram.#getDomEffectBitstring(effect, "root");
+    const root = rootId === null ? null : document.getElementById(rootId);
+
+    if (root === null) {
+      return;
+    }
+
+    DomSelection.restoreDomSelection(root, {
+      anchorPath: Hologram.#getDomEffectIntegerList(effect, "anchor_path"),
+      anchorOffset: Hologram.#getDomEffectInteger(effect, "anchor_offset"),
+      focusPath: Hologram.#getDomEffectIntegerList(effect, "focus_path"),
+      focusOffset: Hologram.#getDomEffectInteger(effect, "focus_offset"),
+    });
+  }
+
+  static #executeFocusEffect(effect) {
+    const elementId = Hologram.#getDomEffectBitstring(effect, "element_id");
+    const element =
+      elementId === null ? null : document.getElementById(elementId);
+
+    element?.focus?.();
+  }
+
+  static #executeTextSelectionEffect(effect) {
+    const elementId = Hologram.#getDomEffectBitstring(effect, "element_id");
+    const element =
+      elementId === null ? null : document.getElementById(elementId);
+
+    if (element === null || typeof element.setSelectionRange !== "function") {
+      return;
+    }
+
+    element.focus?.();
+    element.setSelectionRange(
+      Hologram.#getDomEffectInteger(effect, "selection_start"),
+      Hologram.#getDomEffectInteger(effect, "selection_end"),
+      Hologram.#getDomEffectBitstring(effect, "selection_direction") || "none",
+    );
+  }
+
+  static #getDomEffectBitstring(effect, key) {
+    const value = Hologram.#getDomEffectValue(effect, key);
+
+    return Type.isNil(value) ? null : Bitstring.toText(value);
+  }
+
+  static #getDomEffectInteger(effect, key) {
+    const value = Hologram.#getDomEffectValue(effect, key);
+
+    return Type.isNil(value) ? 0 : Number(value.value);
+  }
+
+  static #getDomEffectIntegerList(effect, key) {
+    const value = Hologram.#getDomEffectValue(effect, key, Type.list());
+
+    return Type.isList(value)
+      ? value.data.map((item) => Number(item.value))
+      : [];
+  }
+
+  static #getDomEffectValue(effect, key, defaultValue = Type.nil()) {
+    return Erlang_Maps["get/3"](Type.atom(key), effect, defaultValue);
+  }
+
   // Deps: [:maps.get/2]
   static #getActionName(action) {
     return Erlang_Maps["get/2"](Type.atom("name"), action).value;
@@ -678,6 +788,9 @@ export default class Hologram {
 
   static #getEventImplementation(eventType) {
     switch (eventType) {
+      case "beforeinput":
+        return BeforeInputEvent;
+
       case "blur":
       case "focus":
         return FocusEvent;
@@ -715,6 +828,9 @@ export default class Hologram {
 
       case "select":
         return SelectEvent;
+
+      case "selectionchange":
+        return SelectionChangeEvent;
 
       case "submit":
         return SubmitEvent;

--- a/assets/js/renderer.mjs
+++ b/assets/js/renderer.mjs
@@ -229,6 +229,13 @@ export default class Renderer {
       return null;
     }
 
+    // selectionchange is fired on document, not on the contenteditable element. A
+    // $selection_change binding on an element is collected as a scoped document listener in
+    // #renderElement, and the event implementation ignores selections outside that element.
+    if (originalEventName === "selection_change") {
+      return null;
+    }
+
     // resize on a real element is delivered by a ResizeObserver, not a DOM event, so it is collected
     // as an observer binding in #renderElement. Returning null keeps it out of the element's "on"
     // map, where the browser would never fire it. A <window> binding (tagName null) keeps flowing
@@ -266,6 +273,7 @@ export default class Renderer {
     effectiveDomEventName,
     defaultTarget,
     getThrottleTarget = (event) => event.currentTarget,
+    transformEvent = (event) => event,
   ) {
     const modifiersDom = attrDom.data[2];
     const allowDefault = $.#allowDefaultFromModifiers(modifiersDom);
@@ -282,8 +290,14 @@ export default class Renderer {
       // payload now, while the event is live, then returns the dispatch (or null when ignored).
       // Only the dispatch is debounced - deferring preventDefault would let the browser's native
       // default fire before it could be blocked.
+      const operationEvent = transformEvent(event);
+
+      if (operationEvent === null) {
+        return;
+      }
+
       const dispatch = Hologram.handleUiEvent(
-        event,
+        operationEvent,
         effectiveDomEventName,
         attrDom.data[1],
         defaultTarget,
@@ -298,7 +312,7 @@ export default class Renderer {
       // The throttle target is read synchronously here - a DOM event nulls its currentTarget after
       // dispatch. Debounce and throttle are mutually exclusive (enforced at compile time), so at
       // most one applies.
-      const throttleTarget = getThrottleTarget(event);
+      const throttleTarget = getThrottleTarget(operationEvent);
 
       if (debounceMs !== null) {
         Debouncer.run(throttleTarget, slotKey, debounceMs, dispatch);
@@ -437,6 +451,44 @@ export default class Renderer {
       );
 
       $.resizeBindings.push({vnode: elementVnode, handler});
+    });
+  }
+
+  // Records each $selection_change attribute as a document-level selectionchange binding scoped
+  // to the rendered element. Browsers fire selectionchange on document, so a per-element listener
+  // would not see caret moves inside a contenteditable root. The transformed event presents the
+  // bound element as target/currentTarget, allowing SelectionChangeEvent to build paths relative
+  // to that root and ignore selections outside it.
+  static #collectSelectionChangeBindings(
+    attrsDom,
+    elementVnode,
+    defaultTarget,
+  ) {
+    attrsDom.data.forEach((attrDom, attrIndex) => {
+      if (Bitstring.toText(attrDom.data[0]) !== "$selection_change") {
+        return;
+      }
+
+      const handler = $.#buildEventHandler(
+        attrDom,
+        attrIndex,
+        "selectionchange",
+        defaultTarget,
+        (event) => event.currentTarget,
+        (event) => ({
+          target: elementVnode.elm,
+          currentTarget: elementVnode.elm,
+          preventDefault: () => event.preventDefault?.(),
+          stopPropagation: () => event.stopPropagation?.(),
+        }),
+      );
+
+      const {key, attach} = EventListeners.domEvent(
+        document,
+        "selectionchange",
+      );
+
+      $.listenerBindings.push({target: document, key, attach, handler});
     });
   }
 
@@ -1085,6 +1137,12 @@ export default class Renderer {
     );
 
     Renderer.#collectResizeBindings(attrsDom, elementVnode, defaultTarget);
+
+    Renderer.#collectSelectionChangeBindings(
+      attrsDom,
+      elementVnode,
+      defaultTarget,
+    );
 
     return elementVnode;
   }

--- a/assets/js/type.mjs
+++ b/assets/js/type.mjs
@@ -118,7 +118,12 @@ export default class Type {
   }
 
   static componentStruct(data = {}) {
-    let {emittedContext, nextAction, nextCommand, nextPage, state} = data;
+    let {domEffects, emittedContext, nextAction, nextCommand, nextPage, state} =
+      data;
+
+    if (typeof domEffects === "undefined") {
+      domEffects = Type.list();
+    }
 
     if (typeof emittedContext === "undefined") {
       emittedContext = Type.map();
@@ -141,6 +146,7 @@ export default class Type {
     }
 
     return Type.struct("Hologram.Component", [
+      [Type.atom("dom_effects"), domEffects],
       [Type.atom("emitted_context"), emittedContext],
       [Type.atom("next_action"), nextAction],
       [Type.atom("next_command"), nextCommand],

--- a/lib/hologram/component.ex
+++ b/lib/hologram/component.ex
@@ -7,7 +7,12 @@ defmodule Hologram.Component do
   alias Hologram.Server
   alias Hologram.Server.Broadcast
 
-  defstruct emitted_context: %{}, next_action: nil, next_command: nil, next_page: nil, state: %{}
+  defstruct dom_effects: [],
+            emitted_context: %{},
+            next_action: nil,
+            next_command: nil,
+            next_page: nil,
+            state: %{}
 
   defmodule Action do
     defstruct delay: 0, name: nil, params: %{}, target: nil
@@ -27,6 +32,7 @@ defmodule Hologram.Component do
   end
 
   @type t :: %__MODULE__{
+          dom_effects: [map],
           emitted_context: %{atom => any} | %{{module, atom} => any},
           next_action: Action.t() | nil,
           next_command: Command.t() | nil,
@@ -81,10 +87,14 @@ defmodule Hologram.Component do
             put_command: 2,
             put_command: 3,
             put_context: 3,
+            put_dom_selection: 2,
+            put_focus: 2,
             put_page: 2,
             put_page: 3,
             put_state: 2,
             put_state: 3,
+            put_text_selection: 4,
+            put_text_selection: 5,
             put_subscription: 2
           ]
 
@@ -355,6 +365,36 @@ defmodule Hologram.Component do
   end
 
   @doc """
+  Queues a post-render DOM selection effect for a contenteditable root.
+
+  The selection node positions are stable child-index paths from the root element to the
+  selected text or element node. The effect is executed by the client after the next DOM patch
+  and is then cleared.
+  """
+  @spec put_dom_selection(Component.t(), keyword | map) :: Component.t()
+  def put_dom_selection(%Component{} = component, opts) do
+    opts = Map.new(opts)
+
+    append_dom_effect(component, %{
+      type: :dom_selection,
+      root: opts[:root],
+      anchor_path: opts[:anchor_path],
+      anchor_offset: opts[:anchor_offset],
+      focus_path: opts[:focus_path],
+      focus_offset: opts[:focus_offset],
+      direction: opts[:direction] || "none"
+    })
+  end
+
+  @doc """
+  Queues a post-render focus effect for the DOM element with the given ID.
+  """
+  @spec put_focus(Component.t(), String.t()) :: Component.t()
+  def put_focus(%Component{} = component, element_id) do
+    append_dom_effect(component, %{type: :focus, element_id: element_id})
+  end
+
+  @doc """
   Puts the given page module to the component's next_page field.
   The client will navigate to this page asynchronously after the current action finished executing.
   """
@@ -402,6 +442,29 @@ defmodule Hologram.Component do
   end
 
   @doc """
+  Queues a post-render text selection effect for an input or textarea element.
+  """
+  @spec put_text_selection(
+          Component.t(),
+          String.t(),
+          non_neg_integer,
+          non_neg_integer,
+          String.t()
+        ) ::
+          Component.t()
+  def put_text_selection(component, element_id, start, finish, direction \\ "none")
+
+  def put_text_selection(%Component{} = component, element_id, start, finish, direction) do
+    append_dom_effect(component, %{
+      type: :text_selection,
+      element_id: element_id,
+      selection_start: start,
+      selection_end: finish,
+      selection_direction: direction
+    })
+  end
+
+  @doc """
   Subscribes the current handler's component to `channel`.
 
   The subscription is scoped to the component whose handler is running - the
@@ -444,6 +507,10 @@ defmodule Hologram.Component do
     quote do
       Module.register_attribute(__MODULE__, :__props__, accumulate: true)
     end
+  end
+
+  defp append_dom_effect(%Component{dom_effects: dom_effects} = component, effect) do
+    %{component | dom_effects: dom_effects ++ [effect]}
   end
 
   defp append_broadcast(server, channel, action_name, params, except \\ []) do

--- a/lib/hologram/page.ex
+++ b/lib/hologram/page.ex
@@ -47,10 +47,14 @@ defmodule Hologram.Page do
             put_command: 2,
             put_command: 3,
             put_context: 3,
+            put_dom_selection: 2,
+            put_focus: 2,
             put_page: 2,
             put_page: 3,
             put_state: 2,
             put_state: 3,
+            put_text_selection: 4,
+            put_text_selection: 5,
             put_subscription: 2
           ]
 

--- a/lib/hologram/runtime/deserializer.ex
+++ b/lib/hologram/runtime/deserializer.ex
@@ -9,6 +9,24 @@ defmodule Hologram.Runtime.Deserializer do
     # change event, select event
     :value,
 
+    # select event, before input event
+    :selection_start,
+    :selection_end,
+    :selection_direction,
+
+    # before input event
+    :data,
+    :input_type,
+    :is_composing,
+
+    # before input event, selection change event
+    :anchor_offset,
+    :anchor_path,
+    :direction,
+    :focus_offset,
+    :focus_path,
+    :selection,
+
     # client-side ERTS node name
     :hologram_client,
 

--- a/test/elixir/hologram/component_test.exs
+++ b/test/elixir/hologram/component_test.exs
@@ -465,6 +465,37 @@ defmodule Hologram.ComponentTest do
            }
   end
 
+  test "put_dom_selection/2" do
+    component = %Component{dom_effects: [%{type: :focus, element_id: "title"}]}
+
+    assert put_dom_selection(component,
+             root: "description-editor",
+             anchor_path: [0, 1],
+             anchor_offset: 4,
+             focus_path: [0, 1],
+             focus_offset: 9
+           ) == %Component{
+             dom_effects: [
+               %{type: :focus, element_id: "title"},
+               %{
+                 type: :dom_selection,
+                 root: "description-editor",
+                 anchor_path: [0, 1],
+                 anchor_offset: 4,
+                 focus_path: [0, 1],
+                 focus_offset: 9,
+                 direction: "none"
+               }
+             ]
+           }
+  end
+
+  test "put_focus/2" do
+    assert put_focus(%Component{}, "title") == %Component{
+             dom_effects: [%{type: :focus, element_id: "title"}]
+           }
+  end
+
   test "put_page/2" do
     assert put_page(%Component{}, MyPage) == %Component{next_page: MyPage}
   end
@@ -516,6 +547,34 @@ defmodule Hologram.ComponentTest do
 
       assert result == %Component{state: %{a: 1, b: %Module5{x: 2, y: 4}}}
     end
+  end
+
+  test "put_text_selection/5" do
+    assert put_text_selection(%Component{}, "title", 1, 3, "backward") == %Component{
+             dom_effects: [
+               %{
+                 type: :text_selection,
+                 element_id: "title",
+                 selection_start: 1,
+                 selection_end: 3,
+                 selection_direction: "backward"
+               }
+             ]
+           }
+  end
+
+  test "put_text_selection/4 defaults direction to none" do
+    assert put_text_selection(%Component{}, "title", 1, 3) == %Component{
+             dom_effects: [
+               %{
+                 type: :text_selection,
+                 element_id: "title",
+                 selection_start: 1,
+                 selection_end: 3,
+                 selection_direction: "none"
+               }
+             ]
+           }
   end
 
   describe "put_subscription/2" do

--- a/test/elixir/hologram/runtime/deserializer_test.exs
+++ b/test/elixir/hologram/runtime/deserializer_test.exs
@@ -4,6 +4,20 @@ defmodule Hologram.Runtime.DeserializerTest do
 
   @delimiter delimiter()
 
+  test "atoms_whitelist/0 includes rich text event payload atoms" do
+    assert :selection_start in atoms_whitelist()
+    assert :selection_end in atoms_whitelist()
+    assert :selection_direction in atoms_whitelist()
+    assert :input_type in atoms_whitelist()
+    assert :is_composing in atoms_whitelist()
+    assert :selection in atoms_whitelist()
+    assert :anchor_path in atoms_whitelist()
+    assert :anchor_offset in atoms_whitelist()
+    assert :focus_path in atoms_whitelist()
+    assert :focus_offset in atoms_whitelist()
+    assert :direction in atoms_whitelist()
+  end
+
   describe "version 3" do
     test "top-level data, raw JSON" do
       assert deserialize(~s'[3,"axyz"]') == :xyz

--- a/test/elixir/hologram/template/renderer_test.exs
+++ b/test/elixir/hologram/template/renderer_test.exs
@@ -968,7 +968,8 @@ defmodule Hologram.Template.RendererTest do
       ETS.put(PageDigestRegistryStub.ets_table_name(), Module25, :dummy_module_25_digest)
 
       assert {~s'layout vars = %{cid: &quot;layout&quot;, prop_1: &quot;prop_value_1&quot;, prop_3: &quot;prop_value_3&quot;}',
-              _component_registry, _server_struct} =
+              _component_registry,
+              _server_struct} =
                render_page(Module25, @params, @server, @opts)
     end
 
@@ -976,7 +977,8 @@ defmodule Hologram.Template.RendererTest do
       ETS.put(PageDigestRegistryStub.ets_table_name(), Module27, :dummy_module_27_digest)
 
       assert {~s'layout vars = %{cid: &quot;layout&quot;, prop_1: &quot;prop_value_1&quot;, prop_3: &quot;prop_value_3&quot;}',
-              _component_registry, _server_struct} =
+              _component_registry,
+              _server_struct} =
                render_page(Module27, @params, @server, @opts)
     end
 
@@ -993,7 +995,8 @@ defmodule Hologram.Template.RendererTest do
       ETS.put(PageDigestRegistryStub.ets_table_name(), Module24, :dummy_module_24_digest)
 
       assert {~s'layout vars = %{cid: &quot;layout&quot;, key_1: &quot;prop_value_1&quot;, key_2: &quot;state_value_2&quot;, key_3: &quot;state_value_3&quot;}',
-              _component_registry, _server_struct} =
+              _component_registry,
+              _server_struct} =
                render_page(Module24, @params, @server, @opts)
     end
 
@@ -1143,7 +1146,7 @@ defmodule Hologram.Template.RendererTest do
                render_page(Module48, @params, @server, @opts)
 
       expected =
-        ~s/componentRegistry: Type.map([[Type.bitstring("layout"), Type.map([[Type.atom("module"), Type.atom("Elixir.Hologram.Test.Fixtures.Template.Renderer.Module49")], [Type.atom("struct"), Type.map([[Type.atom("__struct__"), Type.atom("Elixir.Hologram.Component")], [Type.atom("emitted_context"), Type.map([])], [Type.atom("next_action"), Type.atom("nil")], [Type.atom("next_command"), Type.atom("nil")], [Type.atom("next_page"), Type.atom("nil")], [Type.atom("state"), Type.map([])]])]])], [Type.bitstring("page"), Type.map([[Type.atom("module"), Type.atom("Elixir.Hologram.Test.Fixtures.Template.Renderer.Module48")], [Type.atom("struct"), Type.map([[Type.atom("__struct__"), Type.atom("Elixir.Hologram.Component")], [Type.atom("emitted_context"), Type.map([[Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("csrf_token")]), Type.bitstring("#{@csrf_token}")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("initial_page?")]), Type.atom("false")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("instance_id")]), Type.bitstring("#{@instance_id}")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("page_digest")]), Type.bitstring("102790adb6c3b1956db310be523a7693")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("page_mounted?")]), Type.atom("true")]])], [Type.atom("next_action"), Type.atom("nil")], [Type.atom("next_command"), Type.atom("nil")], [Type.atom("next_page"), Type.atom("nil")], [Type.atom("state"), Type.map([])]])]])]])/
+        ~s/componentRegistry: Type.map([[Type.bitstring("layout"), Type.map([[Type.atom("module"), Type.atom("Elixir.Hologram.Test.Fixtures.Template.Renderer.Module49")], [Type.atom("struct"), Type.map([[Type.atom("__struct__"), Type.atom("Elixir.Hologram.Component")], [Type.atom("dom_effects"), Type.list([])], [Type.atom("emitted_context"), Type.map([])], [Type.atom("next_action"), Type.atom("nil")], [Type.atom("next_command"), Type.atom("nil")], [Type.atom("next_page"), Type.atom("nil")], [Type.atom("state"), Type.map([])]])]])], [Type.bitstring("page"), Type.map([[Type.atom("module"), Type.atom("Elixir.Hologram.Test.Fixtures.Template.Renderer.Module48")], [Type.atom("struct"), Type.map([[Type.atom("__struct__"), Type.atom("Elixir.Hologram.Component")], [Type.atom("dom_effects"), Type.list([])], [Type.atom("emitted_context"), Type.map([[Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("csrf_token")]), Type.bitstring("#{@csrf_token}")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("initial_page?")]), Type.atom("false")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("instance_id")]), Type.bitstring("#{@instance_id}")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("page_digest")]), Type.bitstring("102790adb6c3b1956db310be523a7693")], [Type.tuple([Type.atom("Elixir.Hologram.Runtime"), Type.atom("page_mounted?")]), Type.atom("true")]])], [Type.atom("next_action"), Type.atom("nil")], [Type.atom("next_command"), Type.atom("nil")], [Type.atom("next_page"), Type.atom("nil")], [Type.atom("state"), Type.map([])]])]])]])/
 
       assert String.contains?(html, expected)
     end

--- a/test/javascript/component_registry_test.mjs
+++ b/test/javascript/component_registry_test.mjs
@@ -102,6 +102,32 @@ describe("ComponentRegistry", () => {
     assert.deepStrictEqual(ComponentRegistry.entries, Type.map());
   });
 
+  describe("clearDomEffects()", () => {
+    it("clears dom_effects from the component struct in the registry", () => {
+      const effects = Type.list([
+        Type.map([[Type.atom("type"), Type.atom("focus")]]),
+      ]);
+
+      const struct = Type.componentStruct({domEffects: effects});
+
+      const entry = Type.map([
+        [Type.atom("module"), Type.alias("MyModule")],
+        [Type.atom("struct"), struct],
+      ]);
+
+      ComponentRegistry.entries = Type.map([[cid3, entry]]);
+
+      ComponentRegistry.clearDomEffects(cid3);
+
+      const updatedStruct = ComponentRegistry.getComponentStruct(cid3);
+
+      assert.deepStrictEqual(
+        Erlang_Maps["get/2"](Type.atom("dom_effects"), updatedStruct),
+        Type.list(),
+      );
+    });
+  });
+
   describe("clearNextAction()", () => {
     it("clears next_action from the component struct in the registry", () => {
       const action = Type.actionStruct({

--- a/test/javascript/events/before_input_event_test.mjs
+++ b/test/javascript/events/before_input_event_test.mjs
@@ -1,0 +1,109 @@
+"use strict";
+
+import {
+  assert,
+  defineGlobalErlangAndElixirModules,
+} from "../support/helpers.mjs";
+
+import BeforeInputEvent from "../../../assets/js/events/before_input_event.mjs";
+import Type from "../../../assets/js/type.mjs";
+
+defineGlobalErlangAndElixirModules();
+
+describe("BeforeInputEvent", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    window.getSelection()?.removeAllRanges();
+  });
+
+  it("buildOperationParam() handles text controls", () => {
+    const target = {
+      tagName: "TEXTAREA",
+      value: "Hologram",
+      selectionStart: 1,
+      selectionEnd: 4,
+      selectionDirection: "forward",
+    };
+
+    const event = {
+      target,
+      currentTarget: target,
+      inputType: "insertText",
+      data: "x",
+      isComposing: true,
+    };
+
+    const result = BeforeInputEvent.buildOperationParam(event);
+
+    assert.deepStrictEqual(
+      result,
+      Type.map([
+        [Type.atom("input_type"), Type.bitstring("insertText")],
+        [Type.atom("data"), Type.bitstring("x")],
+        [Type.atom("is_composing"), Type.boolean(true)],
+        [
+          Type.atom("selection"),
+          Type.map([
+            [Type.atom("selection_start"), Type.integer(1)],
+            [Type.atom("selection_end"), Type.integer(4)],
+            [Type.atom("selection_direction"), Type.bitstring("forward")],
+          ]),
+        ],
+        [Type.atom("selection_start"), Type.integer(1)],
+        [Type.atom("selection_end"), Type.integer(4)],
+        [Type.atom("selection_direction"), Type.bitstring("forward")],
+      ]),
+    );
+  });
+
+  it("buildOperationParam() handles contenteditable DOM selections", () => {
+    document.body.innerHTML =
+      '<div id="root" contenteditable="true">ab<span>cd</span></div>';
+
+    const root = document.getElementById("root");
+    const range = document.createRange();
+    range.setStart(root.firstChild, 1);
+    range.setEnd(root.childNodes[1].firstChild, 1);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const result = BeforeInputEvent.buildOperationParam({
+      target: root,
+      currentTarget: root,
+      inputType: "deleteContentBackward",
+      data: null,
+      isComposing: false,
+    });
+
+    assert.deepStrictEqual(
+      result,
+      Type.map([
+        [Type.atom("input_type"), Type.bitstring("deleteContentBackward")],
+        [Type.atom("data"), Type.nil()],
+        [Type.atom("is_composing"), Type.boolean(false)],
+        [
+          Type.atom("selection"),
+          Type.map([
+            [Type.atom("anchor_path"), Type.list([Type.integer(0)])],
+            [Type.atom("anchor_offset"), Type.integer(1)],
+            [
+              Type.atom("focus_path"),
+              Type.list([Type.integer(1), Type.integer(0)]),
+            ],
+            [Type.atom("focus_offset"), Type.integer(1)],
+            [Type.atom("direction"), Type.bitstring("forward")],
+          ]),
+        ],
+        [Type.atom("selection_start"), Type.nil()],
+        [Type.atom("selection_end"), Type.nil()],
+        [Type.atom("selection_direction"), Type.nil()],
+      ]),
+    );
+  });
+
+  it("isEventIgnored()", () => {
+    assert.isFalse(BeforeInputEvent.isEventIgnored({}));
+  });
+});

--- a/test/javascript/events/select_event_test.mjs
+++ b/test/javascript/events/select_event_test.mjs
@@ -12,7 +12,14 @@ defineGlobalErlangAndElixirModules();
 
 describe("SelectEvent", () => {
   const event = {
-    target: {selectionEnd: 15, selectionStart: 6, value: "Hologram 1 Hologram"},
+    target: {
+      tagName: "INPUT",
+      type: "text",
+      selectionEnd: 15,
+      selectionStart: 6,
+      selectionDirection: "none",
+      value: "Hologram 1 Hologram",
+    },
   };
 
   it("buildOperationParam()", () => {
@@ -20,7 +27,28 @@ describe("SelectEvent", () => {
 
     assert.deepStrictEqual(
       result,
-      Type.map([[Type.atom("value"), Type.bitstring("am 1 Holo")]]),
+      Type.map([
+        [Type.atom("value"), Type.bitstring("am 1 Holo")],
+        [Type.atom("selection_start"), Type.integer(6)],
+        [Type.atom("selection_end"), Type.integer(15)],
+        [Type.atom("selection_direction"), Type.bitstring("none")],
+      ]),
+    );
+  });
+
+  it("buildOperationParam() handles non-text controls defensively", () => {
+    const result = SelectEvent.buildOperationParam({
+      target: {tagName: "INPUT", type: "color", value: "#123456"},
+    });
+
+    assert.deepStrictEqual(
+      result,
+      Type.map([
+        [Type.atom("value"), Type.bitstring("")],
+        [Type.atom("selection_start"), Type.nil()],
+        [Type.atom("selection_end"), Type.nil()],
+        [Type.atom("selection_direction"), Type.nil()],
+      ]),
     );
   });
 

--- a/test/javascript/events/selection_change_event_test.mjs
+++ b/test/javascript/events/selection_change_event_test.mjs
@@ -1,0 +1,86 @@
+"use strict";
+
+import {
+  assert,
+  defineGlobalErlangAndElixirModules,
+} from "../support/helpers.mjs";
+
+import SelectionChangeEvent from "../../../assets/js/events/selection_change_event.mjs";
+import Type from "../../../assets/js/type.mjs";
+
+defineGlobalErlangAndElixirModules();
+
+describe("SelectionChangeEvent", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    window.getSelection()?.removeAllRanges();
+  });
+
+  it("buildOperationParam()", () => {
+    document.body.innerHTML =
+      '<div id="root" contenteditable="true">ab<span>cd</span></div>';
+
+    const root = document.getElementById("root");
+    const range = document.createRange();
+    range.setStart(root.firstChild, 1);
+    range.setEnd(root.childNodes[1].firstChild, 1);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const result = SelectionChangeEvent.buildOperationParam({
+      currentTarget: root,
+    });
+
+    assert.deepStrictEqual(
+      result,
+      Type.map([
+        [Type.atom("value"), Type.bitstring("bc")],
+        [
+          Type.atom("selection"),
+          Type.map([
+            [Type.atom("anchor_path"), Type.list([Type.integer(0)])],
+            [Type.atom("anchor_offset"), Type.integer(1)],
+            [
+              Type.atom("focus_path"),
+              Type.list([Type.integer(1), Type.integer(0)]),
+            ],
+            [Type.atom("focus_offset"), Type.integer(1)],
+            [Type.atom("direction"), Type.bitstring("forward")],
+          ]),
+        ],
+      ]),
+    );
+  });
+
+  it("isEventIgnored() returns true when selection is outside the root", () => {
+    document.body.innerHTML =
+      '<div id="root" contenteditable="true">ab</div><p id="outside">cd</p>';
+
+    const root = document.getElementById("root");
+    const outside = document.getElementById("outside");
+    const range = document.createRange();
+    range.selectNodeContents(outside);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    assert.isTrue(SelectionChangeEvent.isEventIgnored({currentTarget: root}));
+  });
+
+  it("isEventIgnored() returns false when selection is inside the root", () => {
+    document.body.innerHTML = '<div id="root" contenteditable="true">ab</div>';
+
+    const root = document.getElementById("root");
+    const range = document.createRange();
+    range.selectNodeContents(root.firstChild);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    assert.isFalse(SelectionChangeEvent.isEventIgnored({currentTarget: root}));
+  });
+});

--- a/test/javascript/hologram_test.mjs
+++ b/test/javascript/hologram_test.mjs
@@ -1238,6 +1238,8 @@ describe("Hologram", () => {
 
   describe("render()", () => {
     afterEach(() => {
+      document.body.innerHTML = "";
+      ComponentRegistry.clear();
       Renderer.listenerBindings = [];
       sinon.restore();
     });
@@ -1259,6 +1261,94 @@ describe("Hologram", () => {
       Hologram.render();
 
       sinon.assert.calledOnceWithExactly(reconcileStub, bindings);
+    });
+
+    it("executes and clears focus effects after patching", () => {
+      document.body.innerHTML = '<button id="focus-target"></button>';
+      const element = document.getElementById("focus-target");
+      const focusSpy = sinon.spy(element, "focus");
+
+      const effect = Type.map([
+        [Type.atom("type"), Type.atom("focus")],
+        [Type.atom("element_id"), Type.bitstring("focus-target")],
+      ]);
+
+      ComponentRegistry.entries = Type.map([
+        [
+          cid1,
+          Type.map([
+            [Type.atom("module"), Type.alias("MyModule")],
+            [
+              Type.atom("struct"),
+              Type.componentStruct({domEffects: Type.list([effect])}),
+            ],
+          ]),
+        ],
+      ]);
+
+      sinon.stub(Renderer, "renderPage").callsFake(() => {
+        Renderer.listenerBindings = [];
+        return {sel: "html", data: {}, children: []};
+      });
+
+      sinon.stub(Vdom, "patchVirtualDocument");
+      sinon.stub(EventListenerRegistry, "reconcile");
+
+      Hologram.render();
+
+      sinon.assert.calledOnce(focusSpy);
+
+      const struct = ComponentRegistry.getComponentStruct(cid1);
+      assert.deepStrictEqual(
+        Erlang_Maps["get/2"](Type.atom("dom_effects"), struct),
+        Type.list(),
+      );
+    });
+
+    it("executes text selection effects after patching", () => {
+      document.body.innerHTML = '<textarea id="editor"></textarea>';
+      const element = document.getElementById("editor");
+      const focusSpy = sinon.spy(element, "focus");
+      const setSelectionRangeSpy = sinon.spy(element, "setSelectionRange");
+
+      const effect = Type.map([
+        [Type.atom("type"), Type.atom("text_selection")],
+        [Type.atom("element_id"), Type.bitstring("editor")],
+        [Type.atom("selection_start"), Type.integer(1)],
+        [Type.atom("selection_end"), Type.integer(3)],
+        [Type.atom("selection_direction"), Type.bitstring("backward")],
+      ]);
+
+      ComponentRegistry.entries = Type.map([
+        [
+          cid1,
+          Type.map([
+            [Type.atom("module"), Type.alias("MyModule")],
+            [
+              Type.atom("struct"),
+              Type.componentStruct({domEffects: Type.list([effect])}),
+            ],
+          ]),
+        ],
+      ]);
+
+      sinon.stub(Renderer, "renderPage").callsFake(() => {
+        Renderer.listenerBindings = [];
+        return {sel: "html", data: {}, children: []};
+      });
+
+      sinon.stub(Vdom, "patchVirtualDocument");
+      sinon.stub(EventListenerRegistry, "reconcile");
+
+      Hologram.render();
+
+      sinon.assert.calledOnce(focusSpy);
+      sinon.assert.calledOnceWithExactly(
+        setSelectionRangeSpy,
+        1,
+        3,
+        "backward",
+      );
     });
   });
 

--- a/test/javascript/renderer_test.mjs
+++ b/test/javascript/renderer_test.mjs
@@ -1156,6 +1156,53 @@ describe("Renderer", () => {
             Hologram.handleUiEvent.restore();
           });
 
+          it("normalizes $before_input event to beforeinput", () => {
+            const node = Type.tuple([
+              Type.atom("element"),
+              Type.bitstring("textarea"),
+              Type.list([
+                Type.tuple([
+                  Type.bitstring("$before_input"),
+                  Type.list([
+                    Type.tuple([
+                      Type.atom("text"),
+                      Type.bitstring("my_action"),
+                    ]),
+                  ]),
+                ]),
+              ]),
+              Type.list(),
+            ]);
+
+            const vdom = Renderer.renderDom(
+              node,
+              context,
+              slots,
+              defaultTarget,
+              parentTagName,
+            );
+
+            assert.deepStrictEqual(Object.keys(vdom.data.on), ["beforeinput"]);
+
+            const stub = sinon
+              .stub(Hologram, "handleUiEvent")
+              .callsFake((..._args) => null);
+
+            vdom.data.on.beforeinput("dummyEvent");
+
+            sinon.assert.calledWith(
+              stub,
+              "dummyEvent",
+              "beforeinput",
+              Type.list([
+                Type.tuple([Type.atom("text"), Type.bitstring("my_action")]),
+              ]),
+              defaultTarget,
+            );
+
+            Hologram.handleUiEvent.restore();
+          });
+
           it("maps $change event to $input event for input element without type attribute", () => {
             const node = Type.tuple([
               Type.atom("element"),
@@ -5608,6 +5655,81 @@ describe("Renderer", () => {
         event,
         "click_outside",
         innerSpecDom,
+        defaultTarget,
+      );
+
+      Hologram.handleUiEvent.restore();
+    });
+  });
+
+  describe("selection_change binding", () => {
+    const actionSpecDom = Type.list([
+      Type.tuple([Type.atom("text"), Type.bitstring("my_action")]),
+    ]);
+
+    const selectionChangeElement = (specDom) =>
+      Type.tuple([
+        Type.atom("element"),
+        Type.bitstring("div"),
+        Type.list([Type.tuple([Type.bitstring("$selection_change"), specDom])]),
+        Type.list(),
+      ]);
+
+    beforeEach(() => {
+      Renderer.listenerBindings = [];
+    });
+
+    it("attaches no per-element listener and collects a document-level selectionchange binding", () => {
+      const vdom = Renderer.renderDom(
+        selectionChangeElement(actionSpecDom),
+        context,
+        slots,
+        defaultTarget,
+        parentTagName,
+      );
+
+      assert.deepStrictEqual(vdom.data.on, {});
+
+      assert.equal(Renderer.listenerBindings.length, 1);
+      assert.equal(Renderer.listenerBindings[0].target, document);
+      assert.equal(Renderer.listenerBindings[0].key, "bubble:selectionchange");
+    });
+
+    it("dispatches with the bound element as event target/currentTarget", () => {
+      const vdom = Renderer.renderDom(
+        selectionChangeElement(actionSpecDom),
+        context,
+        slots,
+        defaultTarget,
+        parentTagName,
+      );
+
+      vdom.elm = {id: "root"};
+
+      const stub = sinon
+        .stub(Hologram, "handleUiEvent")
+        .callsFake(
+          (_event, _eventType, _operationSpecVdom, _defaultTarget) => null,
+        );
+
+      const sourceEvent = {
+        preventDefault: sinon.spy(),
+        stopPropagation: sinon.spy(),
+      };
+
+      Renderer.listenerBindings[0].handler(sourceEvent);
+
+      sinon.assert.calledOnce(stub);
+
+      const scopedEvent = stub.getCall(0).args[0];
+      assert.equal(scopedEvent.target, vdom.elm);
+      assert.equal(scopedEvent.currentTarget, vdom.elm);
+
+      sinon.assert.calledWith(
+        stub,
+        scopedEvent,
+        "selectionchange",
+        actionSpecDom,
         defaultTarget,
       );
 

--- a/test/javascript/type_test.mjs
+++ b/test/javascript/type_test.mjs
@@ -355,6 +355,7 @@ describe("Type", () => {
         Type.componentStruct(),
         Type.map([
           [Type.atom("__struct__"), Type.alias("Hologram.Component")],
+          [Type.atom("dom_effects"), Type.list()],
           [Type.atom("emitted_context"), Type.map()],
           [Type.atom("next_action"), Type.nil()],
           [Type.atom("next_command"), Type.nil()],
@@ -365,6 +366,10 @@ describe("Type", () => {
     });
 
     it("custom values", () => {
+      const domEffects = Type.list([
+        Type.map([[Type.atom("type"), Type.atom("focus")]]),
+      ]);
+
       const emittedContext = Type.map([
         [Type.atom("a"), Type.integer(1)],
         [Type.atom("b"), Type.integer(2)],
@@ -388,6 +393,7 @@ describe("Type", () => {
       ]);
 
       const result = Type.componentStruct({
+        domEffects,
         emittedContext,
         nextAction,
         nextCommand,
@@ -399,6 +405,7 @@ describe("Type", () => {
         result,
         Type.map([
           [Type.atom("__struct__"), Type.alias("Hologram.Component")],
+          [Type.atom("dom_effects"), domEffects],
           [Type.atom("emitted_context"), emittedContext],
           [Type.atom("next_action"), nextAction],
           [Type.atom("next_command"), nextCommand],
@@ -1705,6 +1712,7 @@ describe("Type", () => {
         Type.componentStruct(),
         Type.map([
           [Type.atom("__struct__"), Type.alias("Hologram.Component")],
+          [Type.atom("dom_effects"), Type.list()],
           [Type.atom("emitted_context"), Type.map()],
           [Type.atom("next_action"), Type.nil()],
           [Type.atom("next_command"), Type.nil()],


### PR DESCRIPTION
Adds primitives for reading and restoring text selections, including offsets and direction from relevant input events.

This is needed for building rich text editors and other text-editing experiences that need precise cursor and selection state.

Tests cover the new JavaScript event payload handling, selection registry behavior, rendering integration, and Elixir deserialization/helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added DOM effects system enabling components to restore selections, focus elements, and apply text ranges after rendering
  - Added support for `beforeinput` and `selectionchange` event bindings for enhanced input handling

* **Tests**
  - Added comprehensive test coverage for DOM effects functionality and new event handlers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->