### PR TITLE
Try to avoid Ash reflection pulling in whole resource graph

### DIFF
--- a/lib/hologram/compiler/call_graph.ex
+++ b/lib/hologram/compiler/call_graph.ex
@@ -637,12 +637,11 @@ defmodule Hologram.Compiler.CallGraph do
   @spec list_page_mfas(t, module) :: [mfa]
   def list_page_mfas(call_graph, page_module) do
     entry_mfas = list_page_entry_mfas(page_module)
-    graph = get_graph(call_graph)
 
-    graph
+    call_graph
+    |> get_graph()
     |> sorted_reachable_mfas(entry_mfas)
     |> reject_hex_mfas()
-    |> add_reflection_mfas_reachable_from_server_inits(page_module, graph)
     |> Enum.uniq()
     |> Enum.sort()
   end
@@ -995,48 +994,8 @@ defmodule Hologram.Compiler.CallGraph do
     add_edges(call_graph, edges)
   end
 
-  # Adds reflection MFAs, i.e.:
-  # * __changeset__/0
-  # * __schema__/1
-  # * __schema__/2
-  # * __struct__/0
-  # * __struct__/1
-  # that are reachable from server inits (init/3) of the components used by the page.
-  defp add_reflection_mfas_reachable_from_server_inits(page_mfas, page_module, graph) do
-    templatables = [page_module | extract_uniq_components(page_mfas)]
-
-    added_mfas =
-      Enum.reduce(templatables, [], fn templetable, acc ->
-        acc ++ list_reflection_mfas_reachable_from_server_init(templetable, graph)
-      end)
-
-    page_mfas ++ added_mfas
-  end
-
-  defp extract_uniq_components(mfas) do
-    mfas
-    |> Enum.map(fn {module, _function, _arity} -> module end)
-    |> Enum.uniq()
-    |> Enum.filter(&Reflection.component?/1)
-  end
-
   defp incoming_edges(%{pid: pid}, vertex) do
     Agent.get(pid, &Digraph.incoming_edges(&1, vertex), :infinity)
-  end
-
-  defp list_reflection_mfas_reachable_from_server_init(templetable, graph) do
-    graph
-    |> Digraph.reachable([{templetable, :init, 3}])
-    |> Enum.filter(fn mfa ->
-      case mfa do
-        {_module, :__changeset__, 0} -> true
-        {_module, :__schema__, 1} -> true
-        {_module, :__schema__, 2} -> true
-        {_module, :__struct__, 0} -> true
-        {_module, :__struct__, 1} -> true
-        _falback -> false
-      end
-    end)
   end
 
   defp maybe_add_ecto_schema_call_graph_edges(call_graph, module) do

--- a/test/elixir/hologram/compiler/call_graph_test.exs
+++ b/test/elixir/hologram/compiler/call_graph_test.exs
@@ -37,6 +37,7 @@ defmodule Hologram.Compiler.CallGraphTest do
   alias Hologram.Test.Fixtures.Compiler.CallGraph.Module35
   alias Hologram.Test.Fixtures.Compiler.CallGraph.Module36
   alias Hologram.Test.Fixtures.Compiler.CallGraph.Module37
+  alias Hologram.Test.Fixtures.Compiler.CallGraph.Module38
   alias Hologram.Test.Fixtures.Compiler.CallGraph.Module4
   alias Hologram.Test.Fixtures.Compiler.CallGraph.Module5
   alias Hologram.Test.Fixtures.Compiler.CallGraph.Module6
@@ -905,56 +906,61 @@ defmodule Hologram.Compiler.CallGraphTest do
       refute {String.Chars.Hex.Solver.PackageRange, :to_string, 1} in result
     end
 
-    test "includes reflection MFAs reachable from server inits of components used by the page", %{
+    test "excludes MFAs reachable only from server inits of components used by the page", %{
       page_module_22_mfas: result
     } do
-      assert {Module24, :__changeset__, 0} in result
-      assert {Module24, :__schema__, 1} in result
-      assert {Module24, :__schema__, 2} in result
+      refute {Module24, :__changeset__, 0} in result
+      refute {Module24, :__schema__, 1} in result
+      refute {Module24, :__schema__, 2} in result
 
-      assert {Module25, :__struct__, 0} in result
-      assert {Module25, :__struct__, 1} in result
+      refute {Module25, :__struct__, 0} in result
+      refute {Module25, :__struct__, 1} in result
 
-      assert {Module27, :__changeset__, 0} in result
-      assert {Module27, :__schema__, 1} in result
-      assert {Module27, :__schema__, 2} in result
+      refute {Module27, :__changeset__, 0} in result
+      refute {Module27, :__schema__, 1} in result
+      refute {Module27, :__schema__, 2} in result
 
-      assert {Module28, :__struct__, 0} in result
-      assert {Module28, :__struct__, 1} in result
+      refute {Module28, :__struct__, 0} in result
+      refute {Module28, :__struct__, 1} in result
 
-      assert {Module30, :__changeset__, 0} in result
-      assert {Module30, :__schema__, 1} in result
-      assert {Module30, :__schema__, 2} in result
+      refute {Module30, :__changeset__, 0} in result
+      refute {Module30, :__schema__, 1} in result
+      refute {Module30, :__schema__, 2} in result
 
-      assert {Module31, :__struct__, 0} in result
-      assert {Module31, :__struct__, 1} in result
+      refute {Module31, :__struct__, 0} in result
+      refute {Module31, :__struct__, 1} in result
 
-      assert {Module32, :__changeset__, 0} in result
-      assert {Module32, :__schema__, 1} in result
-      assert {Module32, :__schema__, 2} in result
+      refute {Module32, :__changeset__, 0} in result
+      refute {Module32, :__schema__, 1} in result
+      refute {Module32, :__schema__, 2} in result
 
-      assert {Module33, :__struct__, 0} in result
-      assert {Module33, :__struct__, 1} in result
+      refute {Module33, :__struct__, 0} in result
+      refute {Module33, :__struct__, 1} in result
 
-      assert {Module35, :__changeset__, 0} in result
-      assert {Module35, :__schema__, 1} in result
-      assert {Module35, :__schema__, 2} in result
+      refute {Module35, :__changeset__, 0} in result
+      refute {Module35, :__schema__, 1} in result
+      refute {Module35, :__schema__, 2} in result
 
-      assert {Module36, :__struct__, 0} in result
-      assert {Module36, :__struct__, 1} in result
+      refute {Module36, :__struct__, 0} in result
+      refute {Module36, :__struct__, 1} in result
 
-      assert {Module37, :__struct__, 0} in result
-      assert {Module37, :__struct__, 1} in result
+      refute {Module37, :__struct__, 0} in result
+      refute {Module37, :__struct__, 1} in result
     end
 
-    test "removes duplicate reflection MFAs reachable from server inits of components used by the page",
-         %{page_module_22_mfas: result} do
-      assert Enum.count(result, &(&1 == {Module32, :__changeset__, 0})) == 1
-      assert Enum.count(result, &(&1 == {Module32, :__schema__, 1})) == 1
-      assert Enum.count(result, &(&1 == {Module32, :__schema__, 2})) == 1
+    test "includes Ecto schema reflection MFAs for schema modules reachable from client code", %{
+      full_call_graph: full_call_graph,
+      runtime_mfas: runtime_mfas
+    } do
+      result =
+        full_call_graph
+        |> CallGraph.clone()
+        |> remove_runtime_mfas!(runtime_mfas)
+        |> list_page_mfas(Module38)
 
-      assert Enum.count(result, &(&1 == {Module37, :__struct__, 0})) == 1
-      assert Enum.count(result, &(&1 == {Module37, :__struct__, 1})) == 1
+      assert {Module21, :__changeset__, 0} in result
+      assert {Module21, :__schema__, 1} in result
+      assert {Module21, :__schema__, 2} in result
     end
 
     test "results are deduped", %{page_module_22_mfas: result} do

--- a/test/elixir/support/fixtures/compiler/call_graph/module_38.ex
+++ b/test/elixir/support/fixtures/compiler/call_graph/module_38.ex
@@ -1,0 +1,18 @@
+# credo:disable-for-this-file Credo.Check.Readability.Specs
+defmodule Hologram.Test.Fixtures.Compiler.CallGraph.Module38 do
+  use Hologram.Page
+
+  alias Hologram.Test.Fixtures.Compiler.CallGraph.Module21
+
+  route "/hologram-test-fixtures-compiler-callgraph-module38"
+
+  layout Hologram.Test.Fixtures.DefaultLayout
+
+  def template do
+    ~HOLO""
+  end
+
+  def action(:action_38, _params, component) do
+    put_state(component, :ecto_schema, Module21)
+  end
+end


### PR DESCRIPTION
Draft for discussion.

In Evo Store, page bundles were pulling in large parts of the application because Ash resources are also Ecto schemas. When a server init/3 path touched a resource module, Hologram added the Ecto reflection MFAs: __changeset__/0, __schema__/1, and __schema__/2. The generated Ash/Ecto schema metadata then seemed to pull in the broader resource graph through relationship metadata.

We are not yet sure whether this is due to circular references, association metadata, or something specific to Ash reflection. It also has not been a problem in other Hologram systems so far.

This change stops page bundle MFA selection from adding reflection MFAs that are reachable only from server init/3. It keeps the existing Ecto reflection fallback when an Ecto schema module is reachable from client-side page/component code; the tests cover both cases.

Submitting this as a draft because there was an existing test asserting the opposite behavior, so the goal is to start a discussion on the right semantics and implementation path before treating this as the final fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the compiler's call graph analysis by removing automatic reflection function augmentation from server-side component initializers, focusing on directly reachable code from page entry points.

* **Tests**
  * Updated test coverage and fixtures to validate the streamlined analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->