### PR TITLE
Fix compile.hologram benchmark measuring the no-op path

### DIFF
--- a/benchmarks/elixir/mix/tasks/compile.hologram/README.md
+++ b/benchmarks/elixir/mix/tasks/compile.hologram/README.md
@@ -63,20 +63,20 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">has cache</td>
-    <td style="white-space: nowrap; text-align: right">49.54 K</td>
-    <td style="white-space: nowrap; text-align: right">20.19 &micro;s</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;35.07%</td>
-    <td style="white-space: nowrap; text-align: right">18.54 &micro;s</td>
-    <td style="white-space: nowrap; text-align: right">43.27 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">0.46</td>
+    <td style="white-space: nowrap; text-align: right">2.19 s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2.88%</td>
+    <td style="white-space: nowrap; text-align: right">2.20 s</td>
+    <td style="white-space: nowrap; text-align: right">2.27 s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">no cache</td>
-    <td style="white-space: nowrap; text-align: right">30.15 K</td>
-    <td style="white-space: nowrap; text-align: right">33.17 &micro;s</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;21.68%</td>
-    <td style="white-space: nowrap; text-align: right">31.21 &micro;s</td>
-    <td style="white-space: nowrap; text-align: right">54.12 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">0.21</td>
+    <td style="white-space: nowrap; text-align: right">4.72 s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;0.15%</td>
+    <td style="white-space: nowrap; text-align: right">4.72 s</td>
+    <td style="white-space: nowrap; text-align: right">4.73 s</td>
   </tr>
 
 </table>
@@ -91,14 +91,14 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">has cache</td>
-    <td style="white-space: nowrap;text-align: right">49.54 K</td>
+    <td style="white-space: nowrap;text-align: right">0.46</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">no cache</td>
-    <td style="white-space: nowrap; text-align: right">30.15 K</td>
-    <td style="white-space: nowrap; text-align: right">1.64x</td>
+    <td style="white-space: nowrap; text-align: right">0.21</td>
+    <td style="white-space: nowrap; text-align: right">2.16x</td>
   </tr>
 
 </table>

--- a/benchmarks/elixir/mix/tasks/compile.hologram/run.exs
+++ b/benchmarks/elixir/mix/tasks/compile.hologram/run.exs
@@ -45,6 +45,7 @@ Benchee.run(
       assets_dir: benchmark_assets_dir,
       build_dir: Path.join(benchmark_tmp_dir, "build"),
       esbuild_bin_path: Path.join([node_modules_path, ".bin", "esbuild"]),
+      force?: true,
       js_dir: Path.join(lib_assets_dir, "js"),
       static_dir: Path.join(benchmark_tmp_dir, "static"),
       tmp_dir: Path.join(benchmark_tmp_dir, "tmp")


### PR DESCRIPTION
Closes #920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark results with refreshed performance numbers and comparison figures.
* **Tests**
  * Expanded benchmark scenarios to include an additional run option, affecting both cached and uncached compile measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->