### PR TITLE
Ignore the third cowlib advisory

### DIFF
--- a/test/cluster/mix.exs
+++ b/test/cluster/mix.exs
@@ -62,9 +62,10 @@ defmodule HologramClusterTests.MixProject do
       #
       # cowlib reaches the build only through the Wallaby test-server stack
       # (plug_cowboy -> cowboy -> cowlib), and no cowlib version is registered as patched
-      # for these two, so even 2.19.0 with its cow_http_struct_hd hardening is still
-      # flagged. The MEDIUM one is mitigated by cowboy's CR/LF header validation.
-      hex: [ignore_advisories: ["EEF-CVE-2026-43966", "EEF-CVE-2026-43969"]],
+      # for these three, so even 2.19.0 with its cow_http_struct_hd hardening is still
+      # flagged. Response splitting is mitigated by cowboy's CR/LF header validation, and
+      # nothing in the stack calls the affected cow_link:link/1.
+      hex: [ignore_advisories: ["EEF-CVE-2026-43966", "EEF-CVE-2026-43969", "EEF-CVE-2026-43971"]],
       listeners: [Phoenix.CodeReloader],
       start_permanent: Mix.env() == :prod,
       version: "0.1.0"

--- a/test/features/mix.exs
+++ b/test/features/mix.exs
@@ -63,9 +63,10 @@ defmodule HologramFeatureTests.MixProject do
       #
       # cowlib reaches the build only through the Wallaby test-server stack
       # (plug_cowboy -> cowboy -> cowlib), and no cowlib version is registered as patched
-      # for these two, so even 2.19.0 with its cow_http_struct_hd hardening is still
-      # flagged. The MEDIUM one is mitigated by cowboy's CR/LF header validation.
-      hex: [ignore_advisories: ["EEF-CVE-2026-43966", "EEF-CVE-2026-43969"]],
+      # for these three, so even 2.19.0 with its cow_http_struct_hd hardening is still
+      # flagged. Response splitting is mitigated by cowboy's CR/LF header validation, and
+      # nothing in the stack calls the affected cow_link:link/1.
+      hex: [ignore_advisories: ["EEF-CVE-2026-43966", "EEF-CVE-2026-43969", "EEF-CVE-2026-43971"]],
       listeners: [Phoenix.CodeReloader],
       start_permanent: Mix.env() == :prod,
       version: "0.1.0"

--- a/test/umbrella/mix.exs
+++ b/test/umbrella/mix.exs
@@ -24,9 +24,10 @@ defmodule HologramUmbrellaTests.MixProject do
       #
       # cowlib reaches the build only through the Wallaby test-server stack
       # (plug_cowboy -> cowboy -> cowlib), and no cowlib version is registered as patched
-      # for these two, so even 2.19.0 with its cow_http_struct_hd hardening is still
-      # flagged. The MEDIUM one is mitigated by cowboy's CR/LF header validation.
-      hex: [ignore_advisories: ["EEF-CVE-2026-43966", "EEF-CVE-2026-43969"]],
+      # for these three, so even 2.19.0 with its cow_http_struct_hd hardening is still
+      # flagged. Response splitting is mitigated by cowboy's CR/LF header validation, and
+      # nothing in the stack calls the affected cow_link:link/1.
+      hex: [ignore_advisories: ["EEF-CVE-2026-43966", "EEF-CVE-2026-43969", "EEF-CVE-2026-43971"]],
       # Mix reads :listeners from the project it runs as, which is the umbrella root -
       # declaring it in the endpoint app alone leaves Phoenix's code reloader unregistered.
       listeners: [Phoenix.CodeReloader],


### PR DESCRIPTION
Closes #1042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit configuration across test projects to account for an additional advisory.
  * Expanded documentation describing affected behavior and existing mitigations, including CR/LF validation and unused call paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->