### PR TITLE
Raise badarg when a replacement fun fails

### DIFF
--- a/assets/js/erlang/binary.mjs
+++ b/assets/js/erlang/binary.mjs
@@ -3,6 +3,7 @@
 import Bitstring from "../bitstring.mjs";
 import Erlang from "./erlang.mjs";
 import ERTS from "../erts.mjs";
+import HologramBoxedError from "../errors/boxed_error.mjs";
 import Interpreter from "../interpreter.mjs";
 import Type from "../type.mjs";
 
@@ -955,10 +956,23 @@ const Erlang_Binary = {
     // Helper closes over isReplacementFunction and replacement for clarity
     const buildReplacementBytes = (matchedBitstring, insertPositionsOpt) => {
       if (isReplacementFunction) {
-        const replacementResult = Interpreter.callAnonymousFunction(
-          replacement,
-          [matchedBitstring],
-        );
+        let replacementResult;
+
+        try {
+          replacementResult = Interpreter.callAnonymousFunction(replacement, [
+            matchedBitstring,
+          ]);
+        } catch (error) {
+          // OTP's replace/4 ends its body with a catch-all over every kind, so
+          // whatever the replacement fun raises, throws or exits with leaves
+          // this function as badarg instead. A fault in the runtime itself is
+          // not one of those and is carried out unchanged.
+          if (error instanceof HologramBoxedError) {
+            raiseBadarg();
+          }
+
+          throw error;
+        }
 
         if (!Type.isBinary(replacementResult)) {
           raiseBadarg();
@@ -996,7 +1010,12 @@ const Erlang_Binary = {
 
     // Validate replacement is either binary or function
     const isReplacementBinary = Type.isBinary(replacement);
-    const isReplacementFunction = Type.isAnonymousFunction(replacement);
+
+    // OTP's replace/4 opens its body with is_binary(R) orelse is_function(R, 1),
+    // so a fun of any other arity is rejected before the subject is searched -
+    // it raises even when the pattern has no match at all.
+    const isReplacementFunction =
+      Type.isAnonymousFunction(replacement) && replacement.arity === 1;
 
     if (!isReplacementBinary && !isReplacementFunction) {
       raiseBadarg();

--- a/test/elixir/hologram/ex_js_consistency/erlang/binary_test.exs
+++ b/test/elixir/hologram/ex_js_consistency/erlang/binary_test.exs
@@ -842,6 +842,14 @@ defmodule Hologram.ExJsConsistency.Erlang.BinaryTest do
       assert :binary.replace("hello world", "world", "universe") == "hello universe"
     end
 
+    test "raises ArgumentError if function arity is not 1 and the pattern has no match" do
+      replacement = wrap_term(fn _matched, _extra -> "X" end)
+
+      assert_error ArgumentError,
+                   build_argument_error_msg(3, "not a valid replacement"),
+                   fn -> :binary.replace("hello", "z", replacement) end
+    end
+
     test "error frame carries args and error_info" do
       replacement = wrap_term(:bad)
 
@@ -968,6 +976,62 @@ defmodule Hologram.ExJsConsistency.Erlang.BinaryTest do
                    fn ->
                      :binary.replace("hello", "l", fn _matched -> :not_binary end, [])
                    end
+    end
+
+    test "raises ArgumentError if function arity is not 1" do
+      replacement = wrap_term(fn _matched, _extra -> "X" end)
+
+      assert_error ArgumentError,
+                   build_argument_error_msg(3, "not a valid replacement"),
+                   fn -> :binary.replace("hello", "l", replacement, []) end
+    end
+
+    test "raises ArgumentError if function arity is not 1 and the pattern has no match" do
+      replacement = wrap_term(fn _matched, _extra -> "X" end)
+
+      assert_error ArgumentError,
+                   build_argument_error_msg(3, "not a valid replacement"),
+                   fn -> :binary.replace("hello", "z", replacement, []) end
+    end
+
+    test "raises ArgumentError if function arity is zero" do
+      replacement = wrap_term(fn -> "X" end)
+
+      assert_error ArgumentError,
+                   build_argument_error_msg(3, "not a valid replacement"),
+                   fn -> :binary.replace("hello", "l", replacement, []) end
+    end
+
+    test "raises ArgumentError if the function raises" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(4, "invalid options"),
+                   fn ->
+                     :binary.replace("hello", "l", fn _matched -> raise "boom" end, [])
+                   end
+    end
+
+    test "raises ArgumentError if the function throws" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(4, "invalid options"),
+                   fn ->
+                     :binary.replace("hello", "l", fn _matched -> throw(:boom) end, [])
+                   end
+    end
+
+    test "raises ArgumentError if the function exits" do
+      assert_error ArgumentError,
+                   build_argument_error_msg(4, "invalid options"),
+                   fn ->
+                     :binary.replace("hello", "l", fn _matched -> exit(:boom) end, [])
+                   end
+    end
+
+    test "raises ArgumentError if no function clause matches" do
+      replacement = wrap_term(fn "x" -> "y" end)
+
+      assert_error ArgumentError,
+                   build_argument_error_msg(4, "invalid options"),
+                   fn -> :binary.replace("hello", "l", replacement, []) end
     end
 
     # With :scope option
@@ -1204,6 +1268,23 @@ defmodule Hologram.ExJsConsistency.Erlang.BinaryTest do
       assert {:binary, :replace, ["abc", "b", "x", [scope: {0, 10}]], location} =
                wrap_term(top_frame)
 
+      assert location[:error_info] == %{module: :erl_stdlib_errors}
+    end
+
+    test "error frame carries no cause for a raising replacement function" do
+      replacement = wrap_term(fn _matched -> raise "boom" end)
+
+      top_frame =
+        try do
+          :binary.replace("abc", "b", replacement, [])
+        rescue
+          _error -> hd(wrap_term(__STACKTRACE__))
+        end
+
+      # The server implements this function in Erlang code inside binary.erl,
+      # so its frame location also carries the OTP-internal file and line,
+      # which the client doesn't mirror.
+      assert {:binary, :replace, ["abc", "b", ^replacement, []], location} = wrap_term(top_frame)
       assert location[:error_info] == %{module: :erl_stdlib_errors}
     end
   end

--- a/test/javascript/erlang/binary_test.mjs
+++ b/test/javascript/erlang/binary_test.mjs
@@ -10,8 +10,10 @@ import {
 } from "../support/helpers.mjs";
 
 import Bitstring from "../../../assets/js/bitstring.mjs";
+import Erlang from "../../../assets/js/erlang/erlang.mjs";
 import Erlang_Binary from "../../../assets/js/erlang/binary.mjs";
 import ERTS from "../../../assets/js/erts.mjs";
+import Interpreter from "../../../assets/js/interpreter.mjs";
 import Type from "../../../assets/js/type.mjs";
 
 defineRuntimeGlobals();
@@ -1695,6 +1697,32 @@ describe("Erlang_Binary", () => {
       assertBoxedStrictEqual(result, Bitstring.fromText("hello universe"));
     });
 
+    it("raises ArgumentError if function arity is not 1 and the pattern has no match", () => {
+      const subject = Bitstring.fromText("hello");
+      const pattern = Bitstring.fromText("z");
+
+      const replacement = Type.anonymousFunction(
+        2,
+        [
+          {
+            params: (_context) => [
+              Type.variablePattern("_matched"),
+              Type.variablePattern("_extra"),
+            ],
+            guards: [],
+            body: (_context) => Bitstring.fromText("X"),
+          },
+        ],
+        contextFixture(),
+      );
+
+      assertBoxedError(
+        () => replace(subject, pattern, replacement),
+        "ArgumentError",
+        buildArgumentErrorMsg(3, "not a valid replacement"),
+      );
+    });
+
     it("error frame carries args and error_info", () => {
       const subject = Type.bitstring("abc");
       const pattern = Type.bitstring("b");
@@ -1988,6 +2016,188 @@ describe("Erlang_Binary", () => {
               params: (_context) => [Type.variablePattern("_matched")],
               guards: [],
               body: (_context) => Type.atom("not_binary"),
+            },
+          ],
+          contextFixture(),
+        );
+
+        const options = Type.list();
+
+        assertBoxedError(
+          () => replace(subject, pattern, replacement, options),
+          "ArgumentError",
+          buildArgumentErrorMsg(4, "invalid options"),
+        );
+      });
+
+      it("raises ArgumentError if function arity is not 1", () => {
+        const subject = Bitstring.fromText("hello");
+        const pattern = Bitstring.fromText("l");
+
+        const replacement = Type.anonymousFunction(
+          2,
+          [
+            {
+              params: (_context) => [
+                Type.variablePattern("_matched"),
+                Type.variablePattern("_extra"),
+              ],
+              guards: [],
+              body: (_context) => Bitstring.fromText("X"),
+            },
+          ],
+          contextFixture(),
+        );
+
+        const options = Type.list();
+
+        assertBoxedError(
+          () => replace(subject, pattern, replacement, options),
+          "ArgumentError",
+          buildArgumentErrorMsg(3, "not a valid replacement"),
+        );
+      });
+
+      it("raises ArgumentError if function arity is not 1 and the pattern has no match", () => {
+        const subject = Bitstring.fromText("hello");
+        const pattern = Bitstring.fromText("z");
+
+        const replacement = Type.anonymousFunction(
+          2,
+          [
+            {
+              params: (_context) => [
+                Type.variablePattern("_matched"),
+                Type.variablePattern("_extra"),
+              ],
+              guards: [],
+              body: (_context) => Bitstring.fromText("X"),
+            },
+          ],
+          contextFixture(),
+        );
+
+        const options = Type.list();
+
+        assertBoxedError(
+          () => replace(subject, pattern, replacement, options),
+          "ArgumentError",
+          buildArgumentErrorMsg(3, "not a valid replacement"),
+        );
+      });
+
+      it("raises ArgumentError if function arity is zero", () => {
+        const subject = Bitstring.fromText("hello");
+        const pattern = Bitstring.fromText("l");
+
+        const replacement = Type.anonymousFunction(
+          0,
+          [
+            {
+              params: (_context) => [],
+              guards: [],
+              body: (_context) => Bitstring.fromText("X"),
+            },
+          ],
+          contextFixture(),
+        );
+
+        const options = Type.list();
+
+        assertBoxedError(
+          () => replace(subject, pattern, replacement, options),
+          "ArgumentError",
+          buildArgumentErrorMsg(3, "not a valid replacement"),
+        );
+      });
+
+      it("raises ArgumentError if the function raises", () => {
+        const subject = Bitstring.fromText("hello");
+        const pattern = Bitstring.fromText("l");
+
+        const replacement = Type.anonymousFunction(
+          1,
+          [
+            {
+              params: (_context) => [Type.variablePattern("_matched")],
+              guards: [],
+              body: (_context) =>
+                Interpreter.raiseError("RuntimeError", "boom"),
+            },
+          ],
+          contextFixture(),
+        );
+
+        const options = Type.list();
+
+        assertBoxedError(
+          () => replace(subject, pattern, replacement, options),
+          "ArgumentError",
+          buildArgumentErrorMsg(4, "invalid options"),
+        );
+      });
+
+      it("raises ArgumentError if the function throws", () => {
+        const subject = Bitstring.fromText("hello");
+        const pattern = Bitstring.fromText("l");
+
+        const replacement = Type.anonymousFunction(
+          1,
+          [
+            {
+              params: (_context) => [Type.variablePattern("_matched")],
+              guards: [],
+              body: (_context) => Erlang["throw/1"](Type.atom("boom")),
+            },
+          ],
+          contextFixture(),
+        );
+
+        const options = Type.list();
+
+        assertBoxedError(
+          () => replace(subject, pattern, replacement, options),
+          "ArgumentError",
+          buildArgumentErrorMsg(4, "invalid options"),
+        );
+      });
+
+      it("raises ArgumentError if the function exits", () => {
+        const subject = Bitstring.fromText("hello");
+        const pattern = Bitstring.fromText("l");
+
+        const replacement = Type.anonymousFunction(
+          1,
+          [
+            {
+              params: (_context) => [Type.variablePattern("_matched")],
+              guards: [],
+              body: (_context) => Erlang["exit/1"](Type.atom("boom")),
+            },
+          ],
+          contextFixture(),
+        );
+
+        const options = Type.list();
+
+        assertBoxedError(
+          () => replace(subject, pattern, replacement, options),
+          "ArgumentError",
+          buildArgumentErrorMsg(4, "invalid options"),
+        );
+      });
+
+      it("raises ArgumentError if no function clause matches", () => {
+        const subject = Bitstring.fromText("hello");
+        const pattern = Bitstring.fromText("l");
+
+        const replacement = Type.anonymousFunction(
+          1,
+          [
+            {
+              params: (_context) => [Bitstring.fromText("x")],
+              guards: [],
+              body: (_context) => Bitstring.fromText("X"),
             },
           ],
           contextFixture(),
@@ -2558,6 +2768,39 @@ describe("Erlang_Binary", () => {
           Type.tuple([Type.integer(0), Type.integer(10)]),
         ]),
       ]);
+
+      let caught;
+
+      try {
+        replace(subject, pattern, replacement, options);
+      } catch (e) {
+        caught = e;
+      }
+
+      assert.deepStrictEqual(caught.stacktrace, [
+        binaryErrorFrame(
+          "replace",
+          Type.list([subject, pattern, replacement, options]),
+        ),
+      ]);
+    });
+
+    it("error frame carries no cause for a raising replacement function", () => {
+      const subject = Type.bitstring("abc");
+      const pattern = Type.bitstring("b");
+      const options = Type.list();
+
+      const replacement = Type.anonymousFunction(
+        1,
+        [
+          {
+            params: (_context) => [Type.variablePattern("_matched")],
+            guards: [],
+            body: (_context) => Interpreter.raiseError("RuntimeError", "boom"),
+          },
+        ],
+        contextFixture(),
+      );
 
       let caught;
 


### PR DESCRIPTION
Closes #980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary replacement validation by requiring replacement functions to accept exactly one argument.
  * Standardized handling of errors, throws, exits, and unmatched clauses during replacement operations.
  * Preserved accurate error details and stack-trace information when replacement functions fail.

* **Tests**
  * Added coverage for valid and invalid replacement functions, unmatched patterns, runtime failures, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->